### PR TITLE
Add command to rename group chats

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -476,6 +476,7 @@ FFZ.chat_commands.renamegroup = function(room, args) {
 			"/rooms/" + room.id,
 			{display_name:newname}
 		)
+    return( "Room renamed to \"" + newname + "\"" )
 }
 
 /*FFZ.ffz_commands.massunban = function(room, args) {

--- a/src/commands.js
+++ b/src/commands.js
@@ -449,34 +449,33 @@ FFZ.prototype.get_banned_users = function() {
  // Group Chat Renaming
  // ---------------------
 FFZ.chat_commands.renamegroup = function(room, args) {
-	// Get the current room.
-	var controller = utils.ember_lookup('controller:chat'),
-		room_id = controller.get('currentRoom.id'),
-		room = this.rooms[room_id],
-		has_product = false,
-	  f = this;
+		// Shorten the FFZ instance
+		var f = this;
 
-    //Join the arguments and check to see if something was entered
-		newname = args.join(' ');
-		if ( encodeURI(newname).split(/%..|./).length-1 == 0 ) {
+		// Join the arguments and check to see if something was entered
+		var newname = args.join(' ');
+		if ( ! newname.length ) {
 			return "Usage: /renamegroup <name>\nThis command must be used inside a group chat that you are owner of."
 		}
 
-    //Are we in a group chat and are we the owner?
-		if ( ! f.rooms[room_id].room.get('isGroupRoom') ) {
+		// Are we in a group chat and are we the owner?
+		if ( ! room.room.get('isGroupRoom') ) {
 			return "You must be in a group chat to use renamegroup."
 		}
-	  if ( ! f.rooms[room_id].room.get('isOwner') ) {
-		  return "You must be the owner of the current group chat to use renamegroup."
-	  }
+		if ( ! room.room.get('isOwner') ) {
+			return "You must be the owner of the current group chat to use renamegroup."
+		}
 
-    //Check that the length of the arguments is less than 120 bytes
-		if ( encodeURI(newname).split(/%..|./).length-1 > 120 ) {
+		// Check that the length of the arguments is less than 120 bytes
+		if ( unescape(encodeURIComponent(newname)).length > 120 ) {
 			return "You entered a room name that was too long."
 		}
 
-		//Set the group name
-		f.rooms[room_id].room.tmiRoom.session._depotApi.put("/rooms/"+[room_id],{display_name:newname})
+		// Set the group name
+		room.room.tmiRoom.session._depotApi.put(
+			"/rooms/" + room.id,
+			{display_name:newname}
+		)
 }
 
 /*FFZ.ffz_commands.massunban = function(room, args) {

--- a/src/commands.js
+++ b/src/commands.js
@@ -444,6 +444,41 @@ FFZ.prototype.get_banned_users = function() {
 }
 
 
+
+ // ---------------------
+ // Group Chat Renaming
+ // ---------------------
+FFZ.chat_commands.renamegroup = function(room, args) {
+	// Get the current room.
+	var controller = utils.ember_lookup('controller:chat'),
+		room_id = controller.get('currentRoom.id'),
+		room = this.rooms[room_id],
+		has_product = false,
+	  f = this;
+
+    //Join the arguments and check to see if something was entered
+		newname = args.join(' ');
+		if ( encodeURI(newname).split(/%..|./).length-1 == 0 ) {
+			return "Usage: /renamegroup <name>\nThis command must be used inside a group chat that you are owner of."
+		}
+
+    //Are we in a group chat and are we the owner?
+		if ( ! f.rooms[room_id].room.get('isGroupRoom') ) {
+			return "You must be in a group chat to use renamegroup."
+		}
+	  if ( ! f.rooms[room_id].room.get('isOwner') ) {
+		  return "You must be the owner of the current group chat to use renamegroup."
+	  }
+
+    //Check that the length of the arguments is less than 120 bytes
+		if ( encodeURI(newname).split(/%..|./).length-1 > 120 ) {
+			return "You entered a room name that was too long."
+		}
+
+		//Set the group name
+		f.rooms[room_id].room.tmiRoom.session._depotApi.put("/rooms/"+[room_id],{display_name:newname})
+}
+
 /*FFZ.ffz_commands.massunban = function(room, args) {
 	var user = this.get_user();
 	if ( ! user || (user.login !== room.id && ! user.is_admin && ! user.is_staff) )


### PR DESCRIPTION
Add the `/renamegroup` command which can be used to rename group chats in which you are the owner.