### PR TITLE
Modified the behavior of AutoMod icons when an action is performed

### DIFF
--- a/src/ember/line.js
+++ b/src/ember/line.js
@@ -768,9 +768,18 @@ FFZ.prototype._modify_chat_line = function(component, is_vod) {
 
 			output = ['<span class="mod-icons">'];
 
-			if ( is_tb && ! this.get('hasClickedFlaggedMessage') ) {
-				output.push('<a class="mod-icon html-tooltip tb-reject" title="Not Allowed' + TB_TOOLTIP + '">Not Allowed</a>');
-				output.push('<a class="mod-icon html-tooltip tb-allow" title="Allowed' + TB_TOOLTIP + '">Allowed</a>');
+			if ( is_tb ) {
+				output.push('<span class="tb-actions' + (this.get('hasClickedFlaggedMessage') ? ' inactive' : '') + '">');
+
+				if ( this.get('hasClickedFlaggedMessage') ) {
+					output.push('<a class="mod-icon tb-reject">Not Allowed</a>');
+					output.push('<a class="mod-icon tb-allow">Allowed</a>');
+				} else {
+					output.push('<a class="mod-icon html-tooltip tb-reject" title="Not Allowed' + TB_TOOLTIP + '">Not Allowed</a>');
+					output.push('<a class="mod-icon html-tooltip tb-allow" title="Allowed' + TB_TOOLTIP + '">Allowed</a>');
+				}
+
+				output.push('</span>');
 			}
 
 			if ( is_pinned_cheer ) {

--- a/style.css
+++ b/style.css
@@ -1480,6 +1480,21 @@ body:not(.ffz-hide-friends) .ffz-moderation-card .follow-button {
 }
 
 
+/* AutoMod actions */
+
+.tb-actions {
+  margin-right: 5px;
+}
+
+.tb-actions.inactive {
+  opacity: 0.25;
+}
+
+.tb-actions.inactive .mod-icon {
+  cursor: default;
+}
+
+
 /* Chat Rows */
 
 .conversation-window .conversation-chat-line {


### PR DESCRIPTION
When a user performs an action on AutoMod, the icons are now semi-transparent instead of disappearing completely.
This change avoids moderators clicking on wrong buttons (#77).