### PR TITLE
Added note counter flag to the moderation card

### DIFF
--- a/src/ui/logviewer.js
+++ b/src/ui/logviewer.js
@@ -536,7 +536,9 @@ FFZ.mod_card_pages.history = {
 				msg_line.classList.remove('ffz-mentioned');
 				history.appendChild(msg_line);
 			}
-
+			
+			FFZ.mod_card_pages.notes.update_counter(mod_card, data.comments.length)
+			
 			history.scrollTop = history.scrollHeight;
 		});
 	}
@@ -624,6 +626,11 @@ FFZ.mod_stats_blocks = {
 FFZ.mod_card_pages.notes = {
 	title: "<span>N</span>otes",
 	needs_lv: true,
+	
+	update_counter: function(mod_card, count) {
+		var tabelement = document.getElementById(mod_card.elementId).querySelector(".moderation-card__actions [data-page=notes]");
+		tabelement.innerHTML = '<span>N</span>otes' + ( count > 0 ? ' <div class="note-counter">' + count + '</div>' : '');
+	},
 
 	add_note: function(mod_card, el, note, history, last_line, do_scroll) {
 		if ( ! history )
@@ -653,6 +660,7 @@ FFZ.mod_card_pages.notes = {
 		}
 
 		history.appendChild(output);
+		FFZ.mod_card_pages.notes.update_counter(mod_card, history.querySelectorAll(".message-line").length);
 
 		if ( was_at_bottom )
 			setTimeout(function() { history.scrollTop = history.scrollHeight });

--- a/style.css
+++ b/style.css
@@ -4183,3 +4183,11 @@ body.ffz-sidebar-swap .app-main.theatre #main_col:not(.expandRight) #player[data
 	display: block;
 	max-width: 340px;
 }
+
+.moderation-card div.note-counter {
+	display: inline-block;
+	background-color: #555;
+	color: white;
+	padding: 0 8px;
+	border-radius: 100%;
+}


### PR DESCRIPTION
When there is logviewer notes available on the moderation card, a small flag shows up notifying the user that there is notes available for this user. This is loaded when logs are loaded and updated dynamically as more comments are added.