### PR TITLE
add visibility for how many items in response cache

### DIFF
--- a/socketserver/server/commands.go
+++ b/socketserver/server/commands.go
@@ -32,14 +32,17 @@ var commandHandlers = map[Command]CommandHandler{
 	"track_follow":  C2STrackFollow,
 	"emoticon_uses": C2SEmoticonUses,
 	"survey":        C2SSurvey,
+}
 
-	"twitch_emote":          C2SHandleBunchedCommand,
-	"get_link":              C2SHandleBunchedCommand,
-	"get_display_name":      C2SHandleBunchedCommand,
-	"get_emote":             C2SHandleBunchedCommand,
-	"get_emote_set":         C2SHandleBunchedCommand,
-	"has_logs":              C2SHandleBunchedCommand,
-	"update_follow_buttons": C2SHandleRemoteCommand,
+var bunchedCommands = []string{
+	"get_display_name",
+	"get_emote",
+	"get_emote_set",
+	"get_link",
+	"get_itad_plain",
+	"get_itad_prices",
+	"get_name_history",
+	"has_logs",
 }
 
 func setupInterning() {
@@ -71,6 +74,12 @@ func DispatchC2SCommand(conn *websocket.Conn, client *ClientInfo, msg ClientMess
 	handler, ok := commandHandlers[msg.Command]
 	if !ok {
 		handler = C2SHandleRemoteCommand
+
+		for _, v := range bunchedCommands {
+			if msg.Command == v {
+				handler = C2SHandleBunchedCommand
+			}
+		}
 	}
 
 	CommandCounter <- msg.Command

--- a/socketserver/server/stats.go
+++ b/socketserver/server/stats.go
@@ -38,9 +38,8 @@ type StatsData struct {
 	MemoryInUseKB uint64
 	MemoryRSSKB   uint64
 
-	LowMemDroppedConnections uint64
-
-	MemPerClientBytes uint64
+	ResponseCacheItems uint64
+	MemPerClientBytes  uint64
 
 	CpuUsagePct float64
 
@@ -84,7 +83,7 @@ func commandCounter() {
 }
 
 // StatsDataVersion is the version of the StatsData struct.
-const StatsDataVersion = 7
+const StatsDataVersion = 8
 const pageSize = 4096
 
 var cpuUsage struct {
@@ -170,6 +169,7 @@ func updatePeriodicStats() {
 
 	{
 		Statistics.Uptime = nowUpdate.Sub(Statistics.StartTime).String()
+		Statistics.ResponseCacheItems = Backend.responseCache.ItemCount()
 	}
 
 	{


### PR DESCRIPTION
Simply adds a new element to `/stats` for visibility into the response cache health.

---

Split the list of "bunched" commands out to its own array. Even easier to add new ones now.