### PR TITLE
Don't re-marshal if we already have the JSON

### DIFF
--- a/socketserver/server/handlecore.go
+++ b/socketserver/server/handlecore.go
@@ -586,7 +586,9 @@ func MarshalClientMessage(clientMessage interface{}) (int, []byte, error) {
 		msg.MessageID = -1
 	}
 
-	if msg.Arguments != nil {
+	if msg.origArguments != "" {
+		dataStr = fmt.Sprintf("%d %s %s", msg.MessageID, msg.Command, msg.origArguments)
+	} else if msg.Arguments != nil {
 		argBytes, err := json.Marshal(msg.Arguments)
 		if err != nil {
 			return 0, nil, err


### PR DESCRIPTION
I inspected all callers of client.Send() / SendMessage(), none assign different values to msg.Arguments and msg.origArguments.

This showed up as 12 samples (3% of total executing time) in a 30-second profile. (One sample captured in fmt.Sprintf() from this function, but let's fix this first.)