### PR TITLE
No longer need to call parseOrigArguments().

### DIFF
--- a/socketserver/server/types.go
+++ b/socketserver/server/types.go
@@ -73,7 +73,6 @@ func (cm ClientMessage) ReplyJSON(cmd Command, argsJSON string) ClientMessage {
 		Command:       cmd,
 		origArguments: argsJSON,
 	}
-	n.parseOrigArguments()
 	return n
 }
 


### PR DESCRIPTION
Follow-up to #251 - this should entirely remove JSON parsing from the happy path of remote commands.