### PR TITLE
Brings .tw-tooltip more in line with the dark theme

### DIFF
--- a/src/sites/twitch-twilight/styles/theme.scss
+++ b/src/sites/twitch-twilight/styles/theme.scss
@@ -944,10 +944,10 @@
 	  }
 	}
 	.tw-tooltip {
-	  background-color: var(--ffz-color-4);
-	  color: var(--ffz-color-27);
+	  background-color: var(--ffz-color-56);
+	  color: var(--ffz-color-2);
 	  &:after {
-		background-color: var(--ffz-color-4);
+		background-color: var(--ffz-color-56);
 	  }
 	}
 	.tw-thumbnail-card a:hover .tw-thumbnail-card__title {


### PR DESCRIPTION
Before:  
![before](https://i.imgur.com/t4dwaFU.png)  
After:  
![after](https://i.imgur.com/IcOs7ge.png)