### PR TITLE
Show list of grouped host names in directory tooltip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 npm-debug.log
+package-lock.json
 build
 dist
 Extension Building

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock = false

--- a/src/sites/twitch-twilight/modules/directory/following.js
+++ b/src/sites/twitch-twilight/modules/directory/following.js
@@ -432,13 +432,12 @@ export default class Following extends SiteModule {
 					const channelCardTitle = card.querySelector('.ffz-channel-data .live-channel-card__title');
 
 					const textContent = hostObj.channels.length > 1 ? `${hostObj.channels.length} hosting ${displayName}` : inst.props.title;
-					if (channelCardTitle !== null) {
-						channelCardTitle.textContent
-							= channelCardTitle.title
-							= textContent;
-					}
+					const title = hostObj.channels.length > 1 ? `${hostObj.channels.join(', ')} hosting ${displayName}` : inst.props.title;
 
-					if (thumbnailLink !== null) thumbnailLink.title = textContent;
+					if (channelCardTitle !== null) channelCardTitle.textContent = textContent;
+						
+					if (channelCardTitle !== null) channelCardTitle.title = title;
+					if (thumbnailLink !== null) thumbnailLink.title = title;
 
 					if (titleLink !== null) titleLink.onclick = this.showHostMenu.bind(this, inst, hostObj);
 					if (thumbnailLink !== null) thumbnailLink.onclick = this.showHostMenu.bind(this, inst, hostObj);


### PR DESCRIPTION
Super minor, but it's nice to be able to see who is hosting when hosts have been grouped.
`3 hosting XYZ` -> `A, B, C hosting XYZ`

There's a second commit in there to exclude package-lock, I saw in some previous commit that it was deleted. The repo is using a lockfile for its Go dependencies, so just let me know if there should actually be a package-lock.