### PR TITLE
Add Browse -> Popular support for avatar and uptime

### DIFF
--- a/src/sites/twitch-twilight/modules/directory/browse_popular.js
+++ b/src/sites/twitch-twilight/modules/directory/browse_popular.js
@@ -11,6 +11,8 @@ export default class BrowsePopular extends SiteModule {
 		super(...args);
 
 		this.inject('site.apollo');
+		this.inject('site.fine');
+		this.inject('settings');
 
 		this.apollo.registerModifier('BrowsePage_Popular', `query {
 			streams {
@@ -25,10 +27,33 @@ export default class BrowsePopular extends SiteModule {
 			}
 		}`);
 
+		this.ChannelCard = this.fine.define(
+			'browse-all-channel-card',
+			n => n.props && n.props.channelName && n.props.linkTo && n.props.linkTo.state && n.props.linkTo.state.medium === 'twitch_browse_directory'
+		);
+
 		this.apollo.registerModifier('BrowsePage_Popular', res => this.modifyStreams(res), false);
 	}
 
+	onEnable() {
+		this.ChannelCard.ready((cls, instances) => {
+			// Popular Directory Channel Cards
+			this.apollo.ensureQuery(
+				'BrowsePage_Popular',
+				'data.streams.edges.node.0.createdAt'
+			);
+
+			for(const inst of instances) this.updateChannelCard(inst);
+		});
+
+		this.ChannelCard.on('update', this.updateChannelCard, this);
+		this.ChannelCard.on('mount', this.updateChannelCard, this);
+		this.ChannelCard.on('unmount', this.parent.clearUptime, this);
+	}
+
 	modifyStreams(res) { // eslint-disable-line class-methods-use-this
+		const blockedGames = this.settings.provider.get('directory.game.blocked-games') || [];
+
 		const newStreams = [];
 
 		const edges = res.data.streams.edges;
@@ -42,9 +67,35 @@ export default class BrowsePopular extends SiteModule {
 			s.login = node.broadcaster.login;
 			s.displayName = node.broadcaster.displayName;
 
-			newStreams.push(edge);
+			if (!node.game || node.game && !blockedGames.includes(node.game.name)) newStreams.push(edge);
 		}
 		res.data.streams.edges = newStreams;
 		return res;
+	}
+
+	updateChannelCard(inst) {
+		const container = this.fine.getHostNode(inst);
+		if (!container) return;
+
+		if (container.classList.contains('ffz-modified-channel-card')) return;
+		container.classList.add('ffz-modified-channel-card');
+
+		this.parent.updateUptime(inst, 'props.viewerCount.createdAt', '.tw-card-img');
+		this.parent.addCardAvatar(inst, 'props.viewerCount', '.tw-card');
+
+		const hiddenThumbnails = this.settings.provider.get('directory.game.hidden-thumbnails') || [];
+		const hiddenPreview = 'https://static-cdn.jtvnw.net/ttv-static/404_preview-320x180.jpg';
+
+		if (inst.props.type === 'watch_party')
+			container.classList.toggle('tw-hide', this.settings.get('directory.hide-vodcasts'));
+
+		const img = container.querySelector && container.querySelector('.tw-card-img img');
+		if (img == null) return;
+
+		if (hiddenThumbnails.includes(inst.props.gameTitle)) {
+			img.src = hiddenPreview;
+		} else {
+			img.src = inst.props.imageSrc;
+		}
 	}
 }

--- a/src/sites/twitch-twilight/modules/directory/browse_popular.js
+++ b/src/sites/twitch-twilight/modules/directory/browse_popular.js
@@ -1,0 +1,50 @@
+'use strict';
+
+// ============================================================================
+// Directory (Following, for now)
+// ============================================================================
+
+import {SiteModule} from 'utilities/module';
+
+export default class BrowsePopular extends SiteModule {
+	constructor(...args) {
+		super(...args);
+
+		this.inject('site.apollo');
+
+		this.apollo.registerModifier('BrowsePage_Popular', `query {
+			streams {
+				edges {
+					node {
+						createdAt
+						broadcaster {
+							profileImageURL(width: 70)
+						}
+					}
+				}
+			}
+		}`);
+
+		this.apollo.registerModifier('BrowsePage_Popular', res => this.modifyStreams(res), false);
+	}
+
+	modifyStreams(res) { // eslint-disable-line class-methods-use-this
+		const newStreams = [];
+
+		const edges = res.data.streams.edges;
+		for (let i = 0; i < edges.length; i++) {
+			const edge = edges[i];
+			const node = edge.node;
+
+			const s = node.viewersCount = new Number(node.viewersCount || 0);
+			s.profileImageURL = node.broadcaster.profileImageURL;
+			s.createdAt = node.createdAt;
+			s.login = node.broadcaster.login;
+			s.displayName = node.broadcaster.displayName;
+
+			newStreams.push(edge);
+		}
+		res.data.streams.edges = newStreams;
+		return res;
+	}
+}

--- a/src/sites/twitch-twilight/modules/directory/browse_popular.js
+++ b/src/sites/twitch-twilight/modules/directory/browse_popular.js
@@ -5,6 +5,7 @@
 // ============================================================================
 
 import {SiteModule} from 'utilities/module';
+import {get} from 'utilities/object';
 
 export default class BrowsePopular extends SiteModule {
 	constructor(...args) {
@@ -56,7 +57,9 @@ export default class BrowsePopular extends SiteModule {
 
 		const newStreams = [];
 
-		const edges = res.data.streams.edges;
+		const edges = get('data.streams.edges', res);
+		if (!edges) return res;
+
 		for (let i = 0; i < edges.length; i++) {
 			const edge = edges[i];
 			const node = edge.node;

--- a/src/sites/twitch-twilight/modules/directory/index.js
+++ b/src/sites/twitch-twilight/modules/directory/index.js
@@ -278,6 +278,9 @@ export default class Directory extends SiteModule {
 			setting = this.settings.get('directory.show-channel-avatars'),
 			data = get(created_path, inst);
 
+		if ( ! card )
+			return;
+
 		// Remove old elements
 		const hiddenBodyCard = card.querySelector('.tw-card-body.tw-hide');
 		if (hiddenBodyCard !== null)
@@ -291,7 +294,7 @@ export default class Directory extends SiteModule {
 		if (channelAvatar !== null)
 			channelAvatar.remove();
 
-		if ( ! card || setting === 0 )
+		if ( setting === 0 )
 			return;
 
 		if (data) {

--- a/src/sites/twitch-twilight/modules/directory/index.js
+++ b/src/sites/twitch-twilight/modules/directory/index.js
@@ -183,7 +183,9 @@ export default class Directory extends SiteModule {
 
 		const newStreams = [];
 
-		const edges = res.data.directory.streams.edges;
+		const edges = get('data.directory.streams.edges', res);
+		if (!edges) return res;
+
 		for (let i = 0; i < edges.length; i++) {
 			const edge = edges[i];
 			const node = edge.node;


### PR DESCRIPTION
This PR adds support for channel avatars and stream uptime on the [Browse -> Popular](https://www.twitch.tv/directory/all) directory.