### PR TITLE
Enables 'node' environment support in ESLint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,8 @@
 module.exports = {
     "env": {
         "browser": true,
-        "es6": true
+        "es6": true,
+        "node": true
     },
     "extends": "eslint:recommended",
     "parserOptions": {


### PR DESCRIPTION
[ESLint configuration reference](https://eslint.org/docs/user-guide/configuring#specifying-environments)  
  
While setting up the project in PhpStorm I couldn't figure out why I was getting these errors:  
  
![image](https://user-images.githubusercontent.com/3957791/37485190-c9d0d48a-2858-11e8-9c71-c40c9d09c944.png)
  
Turns out it's because the `node` environment wasn't enabled for ESLint. This PR fixes that.