### PR TITLE
Emote menu multi fetch

### DIFF
--- a/src/sites/twitch-twilight/modules/chat/emote_menu.jsx
+++ b/src/sites/twitch-twilight/modules/chat/emote_menu.jsx
@@ -1567,7 +1567,7 @@ export default class EmoteMenu extends Module {
 		const out = {},
 			curr_nodes = get('data.currentUser.subscriptionBenefits.edges.@each.node', data),
 			has_next_page = get('data.currentUser.subscriptionBenefits.pageInfo.hasNextPage', data),
-			curr_cursor = curr_nodes[curr_nodes.length - 1].id;
+			curr_cursor = get('data.currentUser.subscriptionBenefits.edges.@last.cursor', data);
 
 		nodes = nodes.concat(curr_nodes);
 

--- a/src/sites/twitch-twilight/modules/chat/emote_menu.jsx
+++ b/src/sites/twitch-twilight/modules/chat/emote_menu.jsx
@@ -1535,7 +1535,7 @@ export default class EmoteMenu extends Module {
 	}
 
 
-	async getData(sets, force) {
+	async getData(sets, force, cursor = null, nodes = []) {
 		if ( this._data ) {
 			if ( ! force && set_equals(sets, this._data_sets) )
 				return this._data;
@@ -1551,6 +1551,7 @@ export default class EmoteMenu extends Module {
 				query: SUB_STATUS,
 				variables: {
 					first: 100,
+					after: cursor,
 					criteria: {
 						filter: 'ALL'
 					}
@@ -1564,7 +1565,15 @@ export default class EmoteMenu extends Module {
 		}
 
 		const out = {},
-			nodes = get('data.currentUser.subscriptionBenefits.edges.@each.node', data);
+			curr_nodes = get('data.currentUser.subscriptionBenefits.edges.@each.node', data),
+			has_next_page = get('data.currentUser.subscriptionBenefits.pageInfo.hasNextPage', data),
+			curr_cursor = curr_nodes[curr_nodes.length - 1].id;
+
+		nodes = nodes.concat(curr_nodes);
+
+		if (has_next_page) {
+			return this.getData(sets, force, curr_cursor, nodes);
+		}
 
 		if ( nodes && nodes.length )
 			for(const node of nodes) {

--- a/src/utilities/object.js
+++ b/src/utilities/object.js
@@ -201,7 +201,9 @@ export function get(path, object) {
 
 			break;
 
-		} else
+		} else if ( part === '@last' )
+			object = object[object.length - 1];
+		else
 			object = object[path[i]];
 
 		if ( ! object )


### PR DESCRIPTION
The current implementation of [emote_menu.jsx . getData](https://github.com/FrankerFaceZ/FrankerFaceZ/blob/master/src/sites/twitch-twilight/modules/chat/emote_menu.jsx#L1538) only supports fetching the 100 newest subscription benefits.

This PR adds support for pagination - if it has more available after fetching, it runs the method recursively up until it doesn't have a new page available anymore.