### PR TITLE
Implement timestamp formatting for chat lines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2449,6 +2449,11 @@
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
       "dev": true
     },
+    "dayjs": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.7.7.tgz",
+      "integrity": "sha512-Qlkiu0NNDpYwhk0syK4ImvAl/5YnsEMkvC2O123INviGeOA3Q8s5VyVkZzmN5SC7Wv9bb1+rfwO+uSqtHB4UWw=="
+    },
     "de-indent": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   },
   "dependencies": {
     "crypto-js": "^3.1.9-1",
+    "dayjs": "^1.7.7",
     "displacejs": "^1.2.4",
     "emoji-regex": "^6.5.1",
     "graphql": "^0.13.2",

--- a/src/modules/chat/index.js
+++ b/src/modules/chat/index.js
@@ -3,6 +3,7 @@
 // ============================================================================
 // Chat
 // ============================================================================
+import dayjs from 'dayjs';
 
 import Module from 'utilities/module';
 import {createElement, ManagedStyle} from 'utilities/dom';
@@ -521,6 +522,26 @@ export default class Chat extends Module {
 			}
 		});
 
+		this.settings.add('chat.timestamp-format', {
+			default: 'H:mm',
+			ui: {
+				path: 'Chat > Appearance >> Chat Lines',
+				title: 'Timestamp Format',
+				component: 'setting-select-box',
+
+				data: [
+					{value: 'h:mm', title: 'Default (h:mm)'},
+					{value: 'h:mm:ss', title: 'Default with Seconds (h:mm:ss)'},
+					{value: 'H:mm', title: '24 Hour (H:mm)'},
+					{value: 'H:mm:ss', title: '24 Hour with Seconds (H:mm:ss)'},
+					{value: 'hh:mm', title: 'Padded (hh:mm)'},
+					{value: 'hh:mm:ss', title: 'Padded with Seconds (hh:mm:ss)'},
+					{value: 'HH:mm', title: 'Padded 24 Hour (HH:mm)'},
+					{value: 'HH:mm:ss', title: 'Padded 24 Hour with Seconds (HH:mm:ss)'},
+				]
+			}
+		});
+
 		this.context.on('changed:theme.is-dark', () => {
 			for(const room of this.iterateRooms())
 				room.buildBitsCSS();
@@ -914,22 +935,13 @@ export default class Chat extends Module {
 	}
 
 
-	formatTime(time) { // eslint-disable-line class-methods-use-this
+	formatTime(time) {
 		if (!( time instanceof Date ))
 			time = new Date(time);
 
-		let hours = time.getHours();
+		const fmt = this.settings.get('chat.timestamp-format');
 
-		const minutes = time.getMinutes(); //,
-		//	seconds = time.getSeconds(),
-		//	fmt = this.settings.get('chat.timestamp-format');
-
-		if ( hours > 12 )
-			hours -= 12;
-		else if ( hours === 0 )
-			hours = 12;
-
-		return `${hours}:${minutes < 10 ? '0' : ''}${minutes}`; //:${seconds < 10 ? '0' : ''}${seconds}`;
+		return dayjs(time).format(fmt);
 	}
 
 


### PR DESCRIPTION
This allows the user to select a different formatting for timestamps in chat lines.

Currently supported formats are:
- Default (h:mm)
- Default with Seconds (h:mm:ss)
- 24 Hour (H:mm)
- 24 Hour with Seconds (H:mm:ss)
- Padded (hh:mm)
- Padded with Seconds (hh:mm:ss)
- Padded 24 Hour (HH:mm)
- Padded 24 Hour with Seconds (HH:mm:ss)

Custom formats are supposed to be implemented, too, but as there is no settings component yet to take care of that, this PR is without that.