### PR TITLE
Fix issue#512 - reset player button alignment

### DIFF
--- a/src/sites/twitch-twilight/styles/player.scss
+++ b/src/sites/twitch-twilight/styles/player.scss
@@ -3,8 +3,7 @@
 }
 
 .ffz--player-reset:before {
-	font-size: 2rem;
-	margin-top: .7rem;
+	font-size: 2.1rem;
 }
 
 .player-controls-bottom .player-tip {


### PR DESCRIPTION
Fixes issue #512 by removing `margin-top: .7rem;` and bumping up the font size from `2rem` to `2.1rem` to be proportional to the other player icons.

Changes made:
```
.ffz--player-reset:before {
   font-size: 2.1rem;
}
```

Tested on Chrome Version 69.0.3497.100 and Firefox Version 62.0.3:
<img src="https://i.imgur.com/5gK8Khl.png" />