### PR TITLE
 Add setting to hide live notification when watching a clip / video

### DIFF
--- a/src/sites/twitch-twilight/modules/css_tweaks/index.js
+++ b/src/sites/twitch-twilight/modules/css_tweaks/index.js
@@ -31,6 +31,7 @@ const CLASSES = {
 
 	'dir-live-ind': '.live-channel-card:not([data-a-target*="host"]) .stream-type-indicator.stream-type-indicator--live,.stream-thumbnail__card .stream-type-indicator.stream-type-indicator--live,.preview-card .stream-type-indicator.stream-type-indicator--live,.preview-card .preview-card-stat.preview-card-stat--live',
 	'profile-hover': '.preview-card .tw-relative:hover .ffz-channel-avatar',
+	'not-live-bar': 'div[data-test-selector="non-live-video-banner-layout"]',
 };
 
 
@@ -253,7 +254,7 @@ export default class CSSTweaks extends Module {
 		this.toggleHide('top-discover', !this.settings.get('layout.discover'));
 
 		this.toggle('square-avatars', ! this.settings.get('channel.round-avatars'));
-		this.toggle('not-live-bar', ! this.settings.get('channel.not-live-bar'));
+		this.toggleHide('not-live-bar', ! this.settings.get('channel.not-live-bar'));
 
 		const recs = this.settings.get('layout.side-nav.show-rec-channels');
 		this.toggleHide('side-rec-channels', recs === 0);

--- a/src/sites/twitch-twilight/modules/css_tweaks/index.js
+++ b/src/sites/twitch-twilight/modules/css_tweaks/index.js
@@ -228,6 +228,16 @@ export default class CSSTweaks extends Module {
 			},
 			changed: val => this.toggle('square-avatars', !val)
 		});
+
+		this.settings.add('channel.not-live-bar', {
+			default: true,
+			ui: {
+				path: 'Channel > Appearance >> General',
+				title: 'Show notification below clips and videos if the streamer is live.',
+				component: 'setting-check-box'
+			},
+			changed: val => this.toggle('not-live-bar', !val)
+		});
 	}
 
 	onEnable() {
@@ -243,6 +253,7 @@ export default class CSSTweaks extends Module {
 		this.toggleHide('top-discover', !this.settings.get('layout.discover'));
 
 		this.toggle('square-avatars', ! this.settings.get('channel.round-avatars'));
+		this.toggle('not-live-bar', ! this.settings.get('channel.not-live-bar'));
 
 		const recs = this.settings.get('layout.side-nav.show-rec-channels');
 		this.toggleHide('side-rec-channels', recs === 0);

--- a/src/sites/twitch-twilight/modules/css_tweaks/styles/not-live-bar.scss
+++ b/src/sites/twitch-twilight/modules/css_tweaks/styles/not-live-bar.scss
@@ -1,3 +1,0 @@
-div[data-test-selector="non-live-video-banner-layout"] {
-	display: none;
-}

--- a/src/sites/twitch-twilight/modules/css_tweaks/styles/not-live-bar.scss
+++ b/src/sites/twitch-twilight/modules/css_tweaks/styles/not-live-bar.scss
@@ -1,0 +1,3 @@
+div[data-test-selector="non-live-video-banner-layout"] {
+	display: none;
+}

--- a/src/sites/twitch-twilight/modules/player.jsx
+++ b/src/sites/twitch-twilight/modules/player.jsx
@@ -254,7 +254,7 @@ export default class Player extends Module {
 		this.settings.add('player.hide-event-bar', {
 			default: false,
 			ui: {
-				path: 'Player > General >> General',
+				path: 'Channel > General >> General',
 				title: 'Hide the Event Bar',
 				description: 'Hide the Event Bar which appears above the player when there is an ongoing event for the current channel.',
 				component: 'setting-check-box'
@@ -268,7 +268,7 @@ export default class Player extends Module {
 		this.settings.add('player.hide-rerun-bar', {
 			default: false,
 			ui: {
-				path: 'Player > General >> General',
+				path: 'Channel > General >> General',
 				title: 'Hide the Rerun Bar',
 				description: 'Hide the Rerun Bar which appears above the player when the current channel is playing a video rather than live content.',
 				component: 'setting-check-box'
@@ -282,7 +282,7 @@ export default class Player extends Module {
 		this.settings.add('player.hide-squad-banner', {
 			default: false,
 			ui: {
-				path: 'Player > General >> General',
+				path: 'Channel > General >> General',
 				title: 'Hide the Squad Streaming Bar',
 				component: 'setting-check-box'
 			},

--- a/src/sites/twitch-twilight/modules/player.jsx
+++ b/src/sites/twitch-twilight/modules/player.jsx
@@ -254,7 +254,7 @@ export default class Player extends Module {
 		this.settings.add('player.hide-event-bar', {
 			default: false,
 			ui: {
-				path: 'Channel > General >> General',
+				path: 'Channel > Appearance >> General',
 				title: 'Hide the Event Bar',
 				description: 'Hide the Event Bar which appears above the player when there is an ongoing event for the current channel.',
 				component: 'setting-check-box'
@@ -268,7 +268,7 @@ export default class Player extends Module {
 		this.settings.add('player.hide-rerun-bar', {
 			default: false,
 			ui: {
-				path: 'Channel > General >> General',
+				path: 'Channel > Appearance >> General',
 				title: 'Hide the Rerun Bar',
 				description: 'Hide the Rerun Bar which appears above the player when the current channel is playing a video rather than live content.',
 				component: 'setting-check-box'
@@ -282,7 +282,7 @@ export default class Player extends Module {
 		this.settings.add('player.hide-squad-banner', {
 			default: false,
 			ui: {
-				path: 'Channel > General >> General',
+				path: 'Channel > Appearance >> General',
 				title: 'Hide the Squad Streaming Bar',
 				component: 'setting-check-box'
 			},


### PR DESCRIPTION
This has been requested on Twitter and also in the FFZ Discord and was easier to implement than I initially thought.
Luckily Twitch added a `date-test-selector` on the notification bar.

Also moves the Event, Rerun and Squad Streaming Bar settings from the Player to the Channel section.