### PR TITLE
Fix styling for the Control Center link in the Settings Menu

### DIFF
--- a/src/sites/twitch-twilight/modules/chat/settings_menu.jsx
+++ b/src/sites/twitch-twilight/modules/chat/settings_menu.jsx
@@ -56,9 +56,13 @@ export default class SettingsMenu extends Module {
 				if ( ! this.ffzPauseClick )
 					this.ffzPauseClick = () => this.setState({ffzPauseMenu: ! this.state.ffzPauseMenu});
 
-				val.props.children.push(<div class="tw-mg-t-1">
-					<button onClick={this.ffzSettingsClick}>
-						{t.i18n.t('site.menu_button', 'FrankerFaceZ Control Center')}
+				val.props.children.push(<div class="tw-full-width tw-relative">
+					<button class="tw-block tw-border-radius-medium tw-full-width tw-interactable tw-interactable--inverted tw-interactive" onClick={this.ffzSettingsClick}>
+						<div class="tw-align-items-center tw-flex tw-pd-05 tw-relative">
+							<div class="tw-flex-grow-1">
+								{t.i18n.t('site.menu_button', 'FrankerFaceZ Control Center')}
+							</div>
+						</div>
 					</button>
 					{t.cant_window && <div class="tw-mg-t-05 tw-c-text-alt-2">
 						<span class="ffz-i-attention">


### PR DESCRIPTION
# Information
Twitch has revamped their settings menu, which looks way nicer now, and the FFZ Control Center link looked out of place.

This pull request fixes the styling for the link so it will look much better in the settings menu.

# Old Implementation
![image](https://user-images.githubusercontent.com/1345036/60887267-37e1ac80-a254-11e9-9e61-293a4808a9aa.png)

# New Implementation
![image](https://user-images.githubusercontent.com/1345036/60887274-3b753380-a254-11e9-96ca-5b917b44fd83.png)
