### PR TITLE
Fix tab-complete menu styling

### DIFF
--- a/src/sites/twitch-twilight/modules/chat/input.jsx
+++ b/src/sites/twitch-twilight/modules/chat/input.jsx
@@ -367,7 +367,7 @@ export default class Input extends Module {
 
 		inst.renderFFZEmojiSuggestion = function(data) {
 			return (<React.Fragment>
-				<div class="tw-flex-shrink-0 tw-pd-05" title={data.token} favorite={data.favorite}>
+				<div class="tw-relative tw-flex-shrink-0 tw-pd-05" title={data.token} favorite={data.favorite}>
 					<img
 						class="emote-autocomplete-provider__image ffz-emoji"
 						src={data.src}
@@ -383,7 +383,7 @@ export default class Input extends Module {
 
 		inst.renderEmoteSuggestion = function(emote) {
 			return (<React.Fragment>
-				<div class="tw-flex-shrink-0 tw-pd-05" title={emote.token} favorite={emote.favorite}>
+				<div class="tw-relative tw-flex-shrink-0 tw-pd-05" title={emote.token} favorite={emote.favorite}>
 					<img
 						class="emote-autocomplete-provider__image"
 						srcSet={emote.srcSet}

--- a/src/sites/twitch-twilight/modules/chat/input.jsx
+++ b/src/sites/twitch-twilight/modules/chat/input.jsx
@@ -367,7 +367,7 @@ export default class Input extends Module {
 
 		inst.renderFFZEmojiSuggestion = function(data) {
 			return (<React.Fragment>
-				<div class="tw-relative tw-flex-shrink-0 tw-pd-r-05" title={data.token} favorite={data.favorite}>
+				<div class="tw-flex-shrink-0 tw-pd-05" title={data.token} favorite={data.favorite}>
 					<img
 						class="emote-autocomplete-provider__image ffz-emoji"
 						src={data.src}
@@ -383,7 +383,7 @@ export default class Input extends Module {
 
 		inst.renderEmoteSuggestion = function(emote) {
 			return (<React.Fragment>
-				<div class="tw-relative tw-flex-shrink-0 tw-pd-r-05" title={emote.token} favorite={emote.favorite}>
+				<div class="tw-flex-shrink-0 tw-pd-05" title={emote.token} favorite={emote.favorite}>
 					<img
 						class="emote-autocomplete-provider__image"
 						srcSet={emote.srcSet}


### PR DESCRIPTION
# Information
Twitch's own tab-complete menu has some Y-padding on each emote / result.
Since FFZ is overwriting the render method to add support for the favorite icon, it didn't have that Y-padding implemented up until now.

## Vanilla Twitch
![image](https://user-images.githubusercontent.com/1345036/62401288-d8409d80-b582-11e9-86ac-97362d4f5099.png)

## Current FFZ
![image](https://user-images.githubusercontent.com/1345036/62401293-dd9de800-b582-11e9-8b19-d54125d69b74.png)

## Pull Request
![image](https://user-images.githubusercontent.com/1345036/62401297-e393c900-b582-11e9-9b66-b78a3d77848a.png)
