### PR TITLE
Add setting to hide the `Latest Videos` section

### DIFF
--- a/src/sites/twitch-twilight/modules/directory/index.jsx
+++ b/src/sites/twitch-twilight/modules/directory/index.jsx
@@ -59,9 +59,15 @@ export default class Directory extends SiteModule {
 			DIR_ROUTES
 		);
 
-		this.DirectoryVideos = this.fine.define(
-			'directory-videos',
+		this.DirectorySuggestedVideos = this.fine.define(
+			'directory-suggested-videos',
 			n => n.props && n.props.directoryWidth && n.props.data && n.render && n.render.toString().includes('SuggestedVideos'),
+			DIR_ROUTES
+		);
+
+		this.DirectoryLatestVideos = this.fine.define(
+			'directory-latest-videos',
+			n => n.props && n.props.component === 'LatestVideosFromFollowedCarousel',
 			DIR_ROUTES
 		);
 
@@ -146,7 +152,18 @@ export default class Directory extends SiteModule {
 				component: 'setting-check-box'
 			},
 
-			changed: () => this.DirectoryVideos.forceUpdate()
+			changed: () => this.DirectorySuggestedVideos.forceUpdate()
+		});
+
+		this.settings.add('directory.hide-latest-videos', {
+			default: false,
+			ui: {
+				path: 'Directory > Following >> Categories',
+				title: 'Do not show `Latest Videos` in the Following Directory.',
+				component: 'setting-check-box'
+			},
+
+			changed: () => this.DirectoryLatestVideos.forceUpdate()
 		});
 
 		this.routeClick = this.routeClick.bind(this);
@@ -184,7 +201,7 @@ export default class Directory extends SiteModule {
 			this.DirectoryShelf.forceUpdate();
 		});
 
-		this.DirectoryVideos.ready(cls => {
+		this.DirectorySuggestedVideos.ready(cls => {
 			const old_render = cls.prototype.render;
 			cls.prototype.render = function() {
 				try {
@@ -198,7 +215,24 @@ export default class Directory extends SiteModule {
 				return old_render.call(this);
 			}
 
-			this.DirectoryVideos.forceUpdate();
+			this.DirectorySuggestedVideos.forceUpdate();
+		});
+
+		this.DirectoryLatestVideos.ready(cls => {
+			const old_render = cls.prototype.render;
+			cls.prototype.render = function() {
+				try {
+					if ( t.settings.get('directory.hide-latest-videos') )
+						return null;
+
+				} catch(err) {
+					t.log.capture(err);
+				}
+
+				return old_render.call(this);
+			}
+
+			this.DirectoryLatestVideos.forceUpdate();
 		})
 
 		this.DirectoryCard.ready((cls, instances) => {


### PR DESCRIPTION
# Information
There are already a few settings in place to get a cleaner / simpler `Following` directory, however we didn't have a setting to disable the `Latest Videos` section yet.

This works the same way as the other 2 settings - creating a `fine` hook for it and overriding the `render` method.

# Functionality
![1565339187-390](https://user-images.githubusercontent.com/1345036/62816536-e16dd380-bb5b-11e9-87cc-75bc83ef8525.gif)
