### PR TITLE
Apply custom chat Font Size on chat input as well

### DIFF
--- a/src/sites/twitch-twilight/modules/chat/index.js
+++ b/src/sites/twitch-twilight/modules/chat/index.js
@@ -441,8 +441,7 @@ export default class ChatHook extends Module {
 		this.css_tweaks.toggle('emote-alignment-padded', emote_alignment === 1);
 		this.css_tweaks.toggle('emote-alignment-baseline', emote_alignment === 2);
 
-		for (const chat_input of this.resolve('site.chat.input').ChatInput.instances)
-			chat_input.resizeInput();
+		this.emit(':update-chat-css');
 	}
 
 	updateLineBorders() {

--- a/src/sites/twitch-twilight/modules/chat/index.js
+++ b/src/sites/twitch-twilight/modules/chat/index.js
@@ -440,6 +440,9 @@ export default class ChatHook extends Module {
 
 		this.css_tweaks.toggle('emote-alignment-padded', emote_alignment === 1);
 		this.css_tweaks.toggle('emote-alignment-baseline', emote_alignment === 2);
+
+		for (const chat_input of this.resolve('site.chat.input').ChatInput.instances)
+			chat_input.resizeInput();
 	}
 
 	updateLineBorders() {

--- a/src/sites/twitch-twilight/modules/chat/input.jsx
+++ b/src/sites/twitch-twilight/modules/chat/input.jsx
@@ -218,7 +218,7 @@ export default class Input extends Module {
 		this.EmoteSuggestions.on('mount', this.overrideEmoteMatcher, this);
 		this.MentionSuggestions.on('mount', this.overrideMentionMatcher, this);
 
-		this.on(':update-chat-css', () => {
+		this.on('site.css_tweaks:update-chat-css', () => {
 			for (const chat_input of this.ChatInput.instances)
 				chat_input.resizeInput();
 		}, this);

--- a/src/sites/twitch-twilight/modules/chat/input.jsx
+++ b/src/sites/twitch-twilight/modules/chat/input.jsx
@@ -219,6 +219,11 @@ export default class Input extends Module {
 		this.ChatInput.on('mount', this.overrideChatInput, this);
 		this.EmoteSuggestions.on('mount', this.overrideEmoteMatcher, this);
 		this.MentionSuggestions.on('mount', this.overrideMentionMatcher, this);
+
+		this.on(':update-chat-css', () => {
+			for (const chat_input of this.ChatInput.instances)
+				chat_input.resizeInput();
+		}, this);
 	}
 
 

--- a/src/sites/twitch-twilight/modules/css_tweaks/styles/chat-font.scss
+++ b/src/sites/twitch-twilight/modules/css_tweaks/styles/chat-font.scss
@@ -10,6 +10,7 @@
 	}
 }
 
-textarea[data-a-target="chat-input"] {
+textarea[data-a-target="chat-input"],
+textarea[data-a-target="video-chat-input"] {
 	font-size: var(--ffz-chat-font-size) !important;
 }

--- a/src/sites/twitch-twilight/modules/css_tweaks/styles/chat-font.scss
+++ b/src/sites/twitch-twilight/modules/css_tweaks/styles/chat-font.scss
@@ -9,3 +9,7 @@
 		line-height: var(--ffz-chat-line-height);
 	}
 }
+
+textarea[data-a-target="chat-input"] {
+	font-size: var(--ffz-chat-font-size) !important;
+}


### PR DESCRIPTION
# Information
This PR applies the custom chat font size to the chat input.
There seems to still be a minimum chat input height implemented by Twitch, but I doubt anyone would go below 12 on that setting.

# Functionality
![1565471361-409](https://user-images.githubusercontent.com/1345036/62823502-ac7c7380-bb91-11e9-9aee-0083f18497f0.gif)
