### PR TITLE
Fix `Hide Offline Channels` not working when side-nav is collapsed

### DIFF
--- a/src/sites/twitch-twilight/modules/css_tweaks/index.js
+++ b/src/sites/twitch-twilight/modules/css_tweaks/index.js
@@ -16,7 +16,7 @@ const CLASSES = {
 	'side-friends': '.side-nav .online-friends',
 	'side-closed-friends': '.side-nav--collapsed .online-friends',
 	'side-closed-rec-channels': '.side-nav--collapsed .recommended-channels,.side-nav--collapsed .ffz--popular-channels',
-	'side-offline-channels': '.side-nav-card__link[href*="/videos/"]',
+	'side-offline-channels': '.side-nav-card__link[href*="/videos/"],.side-nav-card[href*="/videos/"]',
 
 	'prime-offers': '.top-nav__prime',
 


### PR DESCRIPTION
# Information
Pretty self-explanatory.
When collapsed the elements have different classes so the selector for this CSS tweak needed to be adjusted.