### PR TITLE
Fix "Hide Latest Videos"

### DIFF
--- a/src/sites/twitch-twilight/modules/directory/index.jsx
+++ b/src/sites/twitch-twilight/modules/directory/index.jsx
@@ -221,6 +221,9 @@ export default class Directory extends SiteModule {
 		this.DirectoryLatestVideos.ready(cls => {
 			const old_render = cls.prototype.render;
 			cls.prototype.render = function() {
+				if ( ! this.props || this.props.component !== 'LatestVideosFromFollowedCarousel' )
+					return old_render.call(this);
+
 				try {
 					if ( t.settings.get('directory.hide-latest-videos') )
 						return null;
@@ -233,7 +236,7 @@ export default class Directory extends SiteModule {
 			}
 
 			this.DirectoryLatestVideos.forceUpdate();
-		})
+		});
 
 		this.DirectoryCard.ready((cls, instances) => {
 			//const old_render = cls.prototype.render,


### PR DESCRIPTION
# Information
Apparently we're matching a component *loader* (since there is no other way I found when finding this), so we need to make sure the props are still correct.

Otherwise we're left with a blank page when the user navigates away from the "Following" page.