### PR TITLE
Fix "Featured Follow"

### DIFF
--- a/src/sites/twitch-twilight/modules/featured_follow.js
+++ b/src/sites/twitch-twilight/modules/featured_follow.js
@@ -119,8 +119,8 @@ export default class FeaturedFollow extends Module {
 				login: user.login,
 				displayName: user.displayName,
 				avatar: user.profileImageURL,
-				following: user.self.follower.followedAt != null,
-				disableNotifications: user.self.follower.disableNotifications
+				following: user.self.follower?.followedAt != null,
+				disableNotifications: user.self.follower?.disableNotifications
 			};
 		}
 


### PR DESCRIPTION
# Information
Apparently Twitch now returns `null` for the `follower` variable inside the user object when the user isn't being followed, so this fixes that by doing a null check.