### PR TITLE
Fix tab-completion duplicates by checking if the emote was added already

### DIFF
--- a/src/sites/twitch-twilight/modules/chat/input.jsx
+++ b/src/sites/twitch-twilight/modules/chat/input.jsx
@@ -554,12 +554,13 @@ export default class Input extends Module {
 				user && user.login,
 				channel_id,
 				channel_login
-			);
+			),
+			added_emotes = new Set();
 
 		for(const set of sets) {
 			if ( set && set.emotes )
 				for(const emote of Object.values(set.emotes))
-					if ( inst.doesEmoteMatchTerm(emote, search) ) {
+					if ( inst.doesEmoteMatchTerm(emote, search) && !added_emotes.has(emote.name) ) {
 						const favorite = this.emotes.isFavorite(set.source || 'ffz', emote.id);
 						results.push({
 							current: input,
@@ -572,6 +573,7 @@ export default class Input extends Module {
 							}),
 							favorite
 						});
+						added_emotes.add(emote.name);
 					}
 		}
 


### PR DESCRIPTION
# Information
When adding emotes to Twitch's own tab-completion there was no check whether or not an emote was already added, so it ended up adding duplicates if the same emote was on both FFZ and BTTV, or if there were featured channels that had the same emotes, too.

## Previously
![image](https://user-images.githubusercontent.com/1345036/64079001-19db7a00-cce2-11e9-9ccb-61b7d0616ee5.png)

## Fixed
![image](https://user-images.githubusercontent.com/1345036/64079006-25c73c00-cce2-11e9-932b-0cb39cbc6a59.png)
