### PR TITLE
Allow filtering extensions' chat messaged based on extension name

### DIFF
--- a/src/modules/chat/index.js
+++ b/src/modules/chat/index.js
@@ -1127,7 +1127,7 @@ export default class Chat extends Module {
 		user.type = user.type || user.userType || null;
 		user.id = user.id || user.userID || null;
 		user.login = user.login || user.userLogin || null;
-		user.displayName = user.displayName || user.userDisplayName || user.login;
+		user.displayName = user.displayName || user.userDisplayName || user.login || ext.displayName;
 		user.isIntl = user.login && user.displayName && user.displayName.trim().toLowerCase() !== user.login;
 
 		// Standardize Message Content


### PR DESCRIPTION
Changed: Chat message filters based on user names now also apply to extension names.

Fixes #685 