### PR TITLE
Added: Ability to hide re-runs in sidebar channel lists

### DIFF
--- a/src/sites/twitch-twilight/modules/css_tweaks/index.js
+++ b/src/sites/twitch-twilight/modules/css_tweaks/index.js
@@ -19,6 +19,7 @@ const CLASSES = {
 	'side-closed-friends': '.side-nav--collapsed .online-friends',
 	'side-closed-rec-channels': '.side-nav--collapsed .recommended-channels,.side-nav--collapsed .ffz--popular-channels',
 	'side-offline-channels': '.side-nav-card__link[href*="/videos/"],.side-nav-card[href*="/videos/"]',
+	'side-rerun-channels': '.side-nav .ffz--side-nav-card-rerun',
 
 	'prime-offers': '.top-nav__prime',
 
@@ -131,6 +132,16 @@ export default class CSSTweaks extends Module {
 				component: 'setting-check-box'
 			},
 			changed: val => this.toggleHide('side-offline-channels', val)
+		});
+
+		this.settings.add('layout.side-nav.hide-reruns', {
+			default: false,
+			ui: {
+				path: 'Appearance > Layout >> Side Navigation',
+				title: 'Hide Reruns',
+				component: 'setting-check-box'
+			},
+			changed: val => this.toggleHide('side-rerun-channels', val)
 		});
 
 		this.settings.add('layout.swap-sidebars', {
@@ -282,6 +293,7 @@ export default class CSSTweaks extends Module {
 		this.toggleHide('side-nav', !this.settings.get('layout.side-nav.show'));
 		this.toggleHide('side-rec-friends', !this.settings.get('layout.side-nav.show-rec-friends'));
 		this.toggleHide('side-offline-channels', this.settings.get('layout.side-nav.hide-offline'));
+		this.toggleHide('side-rerun-channels', this.settings.get('layout.side-nav.hide-reruns'));
 		this.toggleHide('prime-offers', !this.settings.get('layout.prime-offers'));
 		this.toggleHide('top-discover', !this.settings.get('layout.discover'));
 

--- a/src/sites/twitch-twilight/modules/layout.js
+++ b/src/sites/twitch-twilight/modules/layout.js
@@ -35,6 +35,11 @@ export default class Layout extends Module {
 			n => n.getPopularChannels && n.props && has(n.props, 'locale')
 		);
 
+		this.SideBarChannels = this.fine.define(
+			'nav-cards',
+			t => t.getCardSlideInContent && t.props && has(t.props, 'tooltipContent')
+		);
+
 		this.settings.add('layout.portrait', {
 			default: false,
 			ui: {
@@ -179,6 +184,14 @@ export default class Layout extends Module {
 		this.PopularChannels.on('mount', this.updatePopular, this);
 		this.PopularChannels.on('update', this.updatePopular, this);
 
+		this.SideBarChannels.ready((cls, instances) => {
+			for(const inst of instances)
+				this.updateCardClass(inst);
+		});
+
+		this.SideBarChannels.on('mount', this.updateCardClass, this);
+		this.SideBarChannels.on('update', this.updateCardClass, this);
+
 		const t = this;
 		this.RightColumn.ready((cls, instances) => {
 			cls.prototype.ffzHideOnBreakpoint = function() {
@@ -227,6 +240,15 @@ export default class Layout extends Module {
 
 	get is_minimal() {
 		return this.settings.get('layout.is-minimal')
+	}
+
+	updateCardClass(inst) {
+		const node = this.fine.getChildNode(inst);
+
+		if ( node )
+			node.classList.toggle('ffz--side-nav-card-rerun',
+				inst.props?.tooltipContent?.props?.streamType === 'rerun'
+			);
 	}
 
 	updateNavLinks() {


### PR DESCRIPTION
Seems like there's no easier way to do this; a CSS-only approach would (as far as I can tell) require something like CSS4's proposed `:has()` to select the nav card when it contains a child `svg` for the re-run icon. Couldn't find any other classes/properties in the DOM that indicated a channel card was for a re-run.

So, instead, here's an approach that hooks the React component that renders each channel card.

Fixes #683