### PR TITLE
Expose setting to claim bonus points automatically

### DIFF
--- a/src/sites/twitch-twilight/modules/chat/index.js
+++ b/src/sites/twitch-twilight/modules/chat/index.js
@@ -299,6 +299,15 @@ export default class ChatHook extends Module {
 			}
 		});
 
+		this.settings.add('chat.points.auto-rewards', {
+			default: false,
+			ui: {
+				path: 'Chat > Channel Points >> General',
+				title: 'Claim bonus Channel Points automatically.',
+				component: 'setting-check-box',
+			}
+		});
+
 		this.settings.add('chat.points.show-rewards', {
 			default: true,
 			ui: {


### PR DESCRIPTION
I went to add a feature that would make FFZ automatically collect bonus points when Twitch gives the prompt at the bottom of the chat window. While looking through the code, I realized @SirStendec already implemented it in 89d243a2 but never exposed the setting for the `chat.points.auto-rewards` flag. This PR adds that setting.

I have a feeling FFZ hides this setting for a reason—perhaps at the request of Twitch or concerns with Twitch TOS. However, if it was an oversight, this PR corrects it.