### PR TITLE
socketserver: Serve metrics in prometheus format

### DIFF
--- a/socketserver/server/commands.go
+++ b/socketserver/server/commands.go
@@ -139,13 +139,19 @@ func C2SHello(_ *websocket.Conn, client *ClientInfo, msg ClientMessage) (_ Clien
 	if clientIDStr, ok := ary[1].(string); ok {
 		clientID = uuid.FromStringOrNil(clientIDStr)
 		if clientID == uuid.Nil {
-			clientID = uuid.NewV4()
+			clientID, err = uuid.NewV4()
+			if err != nil {
+				panic(err) // randomness should not fail
+			}
 		}
 	} else if _, ok := ary[1].(bool); ok {
 		// opt out
 		clientID = AnonymousClientID
 	} else if ary[1] == nil {
-		clientID = uuid.NewV4()
+		clientID, err = uuid.NewV4()
+		if err != nil {
+			panic(err) // randomness should not fail
+		}
 	} else {
 		err = ErrExpectedTwoStrings
 		return

--- a/socketserver/server/handlecore.go
+++ b/socketserver/server/handlecore.go
@@ -90,6 +90,7 @@ func SetupServerAndHandle(config *ConfigFile, serveMux *http.ServeMux) {
 	serveMux.Handle("/.well-known/", http.FileServer(http.Dir("/tmp/letsencrypt/")))
 	serveMux.HandleFunc("/healthcheck", HTTPSayOK)
 	serveMux.HandleFunc("/stats", HTTPShowStatistics)
+	serveMux.HandleFunc("/metrics", HTTPShowStatisticsPrometheus)
 	serveMux.HandleFunc("/hll/", HTTPShowHLL)
 	serveMux.HandleFunc("/hll_force_write", HTTPWriteHLL)
 


### PR DESCRIPTION
Prometheus format is becoming more popular for serving metrics, so let's convert our existing metrics to also be served in that format!

Did it bare-hands mostly because I wanted to show off but also because the client library is fairly bloated and would drag in protobuf.