### PR TITLE
Improve tab complete caching and add support for hiding whole emote sets

### DIFF
--- a/src/modules/chat/emotes.js
+++ b/src/modules/chat/emotes.js
@@ -227,6 +227,10 @@ export default class Emotes extends Module {
 		return this.getHidden(source).includes(id);
 	}
 
+	isSetHidden(source, id) {
+		return this.settings.provider.get('emote-menu.hidden-sets').includes(`${source}-${id}`);
+	}
+
 	getHidden(source) {
 		return this.settings.provider.get(`hidden-emotes.${source}`, []);
 	}

--- a/src/sites/twitch-twilight/modules/chat/emote_menu.jsx
+++ b/src/sites/twitch-twilight/modules/chat/emote_menu.jsx
@@ -562,9 +562,11 @@ export default class EmoteMenu extends Module {
 					if ( idx === -1 ) {
 						hidden.push(key);
 						this.setState({hidden: true});
+						t.emit(':change-hidden-set', key, true);
 					} else {
 						hidden.splice(idx, 1);
 						this.setState({hidden: false});
+						t.emit(':change-hidden-set', key, false);
 					}
 
 					storage.set('emote-menu.hidden-sets', hidden);

--- a/src/sites/twitch-twilight/modules/chat/input.jsx
+++ b/src/sites/twitch-twilight/modules/chat/input.jsx
@@ -478,6 +478,13 @@ export default class Input extends Module {
 			return [];
 		}
 
+		for (let i = 0; i < hydratedEmotes.length; i++) {
+			const owner = inst.props.emotes[i].owner;
+			if (owner) {
+				hydratedEmotes[i].owner = owner;
+			}
+		}
+
 		const usageResults = [],
 			startingResults = [],
 			otherResults = [],
@@ -487,27 +494,29 @@ export default class Input extends Module {
 
 		for (const set of hydratedEmotes) {
 			if (set && Array.isArray(set.emotes)) {
-				for (const emote of set.emotes) {
-					if (inst.doesEmoteMatchTerm(emote, search) && ! hidden.includes(emote.id)) {
-						const favorite = favorites.includes(emote.id);
-						const element = {
-							current: input,
-							replacement: emote.token,
-							element: inst.renderEmoteSuggestion({
-								...emote,
+				if ( ! this.emotes.isSetHidden('twitch', set.owner?.id)) {
+					for (const emote of set.emotes) {
+						if (inst.doesEmoteMatchTerm(emote, search) && ! hidden.includes(emote.id)) {
+							const favorite = favorites.includes(emote.id);
+							const element = {
+								current: input,
+								replacement: emote.token,
+								element: inst.renderEmoteSuggestion({
+									...emote,
+									favorite
+								}),
 								favorite
-							}),
-							favorite
-						};
+							};
 
-						if (this.EmoteUsageCount[emote.token]) {
-							usageResults.push(element);
-						}
-						else if (emote.token.toLowerCase().startsWith(search)) {
-							startingResults.push(element);
-						}
-						else {
-							otherResults.push(element);
+							if (this.EmoteUsageCount[emote.token]) {
+								usageResults.push(element);
+							}
+							else if (emote.token.toLowerCase().startsWith(search)) {
+								startingResults.push(element);
+							}
+							else {
+								otherResults.push(element);
+							}
 						}
 					}
 				}
@@ -590,22 +599,23 @@ export default class Input extends Module {
 
 		for(const set of sets) {
 			if ( set && set.emotes )
-				for(const emote of Object.values(set.emotes))
-					if ( inst.doesEmoteMatchTerm(emote, search) && !added_emotes.has(emote.name) && ! this.emotes.isHidden(set.source || 'ffz', emote.id) ) {
-						const favorite = this.emotes.isFavorite(set.source || 'ffz', emote.id);
-						results.push({
-							current: input,
-							replacement: emote.name,
-							element: inst.renderEmoteSuggestion({
-								token: emote.name,
-								id: `${set.source}-${emote.id}`,
-								srcSet: emote.srcSet,
+				if ( ! this.emotes.isSetHidden(set.source || 'ffz', set.id))
+					for(const emote of Object.values(set.emotes))
+						if ( inst.doesEmoteMatchTerm(emote, search) && !added_emotes.has(emote.name) && ! this.emotes.isHidden(set.source || 'ffz', emote.id) ) {
+							const favorite = this.emotes.isFavorite(set.source || 'ffz', emote.id);
+							results.push({
+								current: input,
+								replacement: emote.name,
+								element: inst.renderEmoteSuggestion({
+									token: emote.name,
+									id: `${set.source}-${emote.id}`,
+									srcSet: emote.srcSet,
+									favorite
+								}),
 								favorite
-							}),
-							favorite
-						});
-						added_emotes.add(emote.name);
-					}
+							});
+							added_emotes.add(emote.name);
+						}
 		}
 
 		return results;

--- a/src/sites/twitch-twilight/modules/chat/input.jsx
+++ b/src/sites/twitch-twilight/modules/chat/input.jsx
@@ -503,13 +503,6 @@ export default class Input extends Module {
 					const owner = inst.props.emotes[i].owner;
 					if (owner && this.emotes.isSetHidden('twitch', owner.id)) {
 						continue;
-
-						// // In case we do still need the owner information
-						// filteredSet.owner = owner;
-						
-						// if (this.emotes.isSetHidden('twitch', owner.id)) {
-						// 	continue;
-						// }
 					}
 
 					for (let i = 0; i < set.emotes.length; i++) {


### PR DESCRIPTION
This PR improves the tab-completion cache and adds support for hiding whole emote sets (next to single emotes) in the tab-completion.

The cache improvements are making sure we aren't fetching and building the whole list of emote sets on every key-press (like Twitch does).