### PR TITLE
Disable channel.extra-links by default

### DIFF
--- a/src/sites/twitch-twilight/modules/channel.jsx
+++ b/src/sites/twitch-twilight/modules/channel.jsx
@@ -40,7 +40,7 @@ export default class Channel extends Module {
 		});
 
 		this.settings.add('channel.extra-links', {
-			default: true,
+			default: false,
 			ui: {
 				path: 'Channel > Appearance >> General',
 				title: 'Add extra links to live channel pages, next to the streamer\'s name.',


### PR DESCRIPTION
The new setting channel.extra-links is great but is confusing users thinking it is a native Twitch feature. Given not much CSS or "beautifying" work was put into it, we're modifying an experience by default that should only be added as an "opt-in" not "by default" - this PR changes the setting to off by default. 