### PR TITLE
Fix the crash on the whispers when twitch limits your messages

### DIFF
--- a/src/sites/twitch-twilight/modules/chat/line.js
+++ b/src/sites/twitch-twilight/modules/chat/line.js
@@ -178,7 +178,7 @@ export default class ChatLine extends Module {
 			cls.prototype.render = function() {
 				this._ffz_no_scan = true;
 
-				if ( ! this.props.message || ! this.props.message.content )
+				if ( ! this.props.message || ! this.props.message.content || ! this.props.message.from )
 					return old_render.call(this);
 
 				const msg = t.chat.standardizeWhisper(this.props.message),


### PR DESCRIPTION
Sometimes, twitch limits your sent whispers and refuses to deliver them, giving you a `Your whisper was not delivered` as a response. When that happens, FFZ still tries to sanitize the message, and fails when it tries to get the users colors, it crashes and closes the whisper, because the `from` is not present there (as it is a system message, not a user message):
https://github.com/FrankerFaceZ/FrankerFaceZ/blob/472f9472ee0523293caa02adf8b59933bc5b1650/src/modules/chat/index.js#L1142-L1151

By calling the old render on that message, the issue is fixed.

On the if statement, maybe we could also check if the message type is 5, but i'm not sure if thats only the case when it is a system message, so checking the `from` seemed safer, as the lack of that property is what causes the method to fail.

closes #904