### PR TITLE
Fix the wrong profile order priority on highlight settings

### DIFF
--- a/src/modules/chat/index.js
+++ b/src/modules/chat/index.js
@@ -480,14 +480,14 @@ export default class Chat extends Module {
 				if ( ! val || ! val.length )
 					return null;
 
+				const colorWithHighestPriority = val[0]
+
 				const colors = new Map;
 
-				for(const item of val) {
-					const c = item.c || null,
-						v = item.v;
+				const c = colorWithHighestPriority.c || null,
+					v = colorWithHighestPriority.v;
 
-					colors.set(v, c);
-				}
+				colors.set(v, c);
 
 				return colors;
 			}


### PR DESCRIPTION
This change makes it so that we don't override the badge highlight colors when there are multiple profiles with that configuration set. When we only use the first entry, we get the entry of the first profile, which should be the one with the highest priority.

closes #908