### PR TITLE
[WIP?] add users to watchlist (quick highlight)

### DIFF
--- a/src/modules/chat/actions/index.jsx
+++ b/src/modules/chat/actions/index.jsx
@@ -69,7 +69,8 @@ export default class Actions extends Module {
 				{v: {action: 'unban', appearance: {type: 'icon', icon: 'ffz-i-ok'}, options: {}, display: {mod: true, mod_icons: true, deleted: true}}},
 				{v: {action: 'timeout', appearance: {type: 'icon', icon: 'ffz-i-clock'}, display: {mod: true, mod_icons: true}}},
 				{v: {action: 'msg_delete', appearance: {type: 'icon', icon: 'ffz-i-trash'}, options: {}, display: {mod: true, mod_icons: true}}},
-				{v: {action: 'reply', appearance: {type: 'icon', icon: 'ffz-i-reply'}, options: {}, display: {}}}
+				{v: {action: 'reply', appearance: {type: 'icon', icon: 'ffz-i-reply'}, options: {}, display: {}}},
+				{v: {action: 'highlight', appearance: {type: 'icon', icon: 'ffz-i-eye'}, options: {}, display: {}}}
 			],
 
 			type: 'array_merge',

--- a/src/modules/chat/actions/types.jsx
+++ b/src/modules/chat/actions/types.jsx
@@ -382,6 +382,7 @@ export const highlight = {
 		else
 			val.push(data.user.id)
 		this.settings.provider.set(key, val)
+		this.resolve('chat').emit('chat:update-lines')
 	}
 }
 

--- a/src/modules/chat/actions/types.jsx
+++ b/src/modules/chat/actions/types.jsx
@@ -369,7 +369,7 @@ export const highlight = {
 	title: 'Highlight User',
 
 	tooltip(data) {
-		return this.i18n.t('chat.actions.highlight.tooltip', 'Highlight {user.login}', {user: data});
+		return this.i18n.t('chat.actions.highlight.tooltip', `Highlight ${data.user.login}`);
 	},
 
 	click(event, data) {

--- a/src/modules/chat/actions/types.jsx
+++ b/src/modules/chat/actions/types.jsx
@@ -354,6 +354,39 @@ export const untimeout = {
 	}
 }
 
+export const highlight = {
+	presets: [{
+		appearance: {
+			type: 'icon',
+			icon: 'ffz-i-eye'
+		},
+	}],
+
+	defaults: {},
+
+	required_context: ['user'],
+
+	title: 'Highlight User',
+
+	tooltip(data) {
+		return this.i18n.t('chat.actions.highlight.tooltip', 'Highlight {user.login}', {user: data});
+	},
+
+	click(event, data) {
+		let key = 'chat.filtering.highlight-temp'
+		let val = this.settings.provider.get(key)
+		if(!val)
+			val = []
+		if(val.includes(data.user.id))
+			val = val.filter(value => value !== data.user.id);
+		else
+			val.push(data.user.id)
+		this.settings.provider.set(key, val)
+	}
+}
+
+
+
 
 // ============================================================================
 // Whisper

--- a/src/modules/chat/index.js
+++ b/src/modules/chat/index.js
@@ -363,6 +363,16 @@ export default class Chat extends Module {
 			}
 		});
 
+		this.settings.add('chat.filtering.highlight-basic-users-temp', {
+			default: [],
+			type: 'array_merge',
+			always_inherit: true,
+			ui: {
+				path: 'Chat > Filtering >> Temporary User Highlights',
+				component: 'temp-highlights',
+			}
+		});
+
 		this.settings.add('chat.filtering.highlight-basic-users--color-regex', {
 			requires: ['chat.filtering.highlight-basic-users'],
 			equals: 'requirements',

--- a/src/modules/chat/tokenizers.jsx
+++ b/src/modules/chat/tokenizers.jsx
@@ -433,6 +433,13 @@ export const UserHighlights = {
 			}
 		}
 
+		if(this.context.manager.provider.get('chat.filtering.highlight-temp')?.includes(msg.user.userID))
+		{
+			(msg.highlights = (msg.highlights || new Set())).add('user');
+			msg.mentioned = true;
+			return tokens;
+		}
+
 		return tokens;
 	}
 }

--- a/src/modules/main_menu/components/temp-highlights.vue
+++ b/src/modules/main_menu/components/temp-highlights.vue
@@ -1,0 +1,42 @@
+<template lang="html">
+	<section class="ffz--widget">
+		<button
+			class="tw-button tw-mg-x-1"
+			@click="clear"
+		>
+			<span class="tw-button__icon tw-button__icon--left">
+				<figure class="ffz-i-trash" />
+			</span>
+			<span class="tw-button__text">
+				{{ t('setting.highlights-temp.clear', 'Clear highlights') }}
+			</span>
+		</button>
+	</section>
+</template>
+
+<script>
+
+import SettingMixin from '../setting-mixin';
+
+export default {
+	mixins: [SettingMixin],
+	props: ['item', 'context'],
+
+	data() {
+		return {
+			error_desc: null,
+			error: false,
+			message: null
+		}
+	},
+
+	methods: {
+		clear(){
+			const settings = this.context.getFFZ().resolve('settings')
+			settings.provider.delete('chat.filtering.highlight-temp')
+			this.context.getFFZ().resolve('chat').emit('chat:update-lines')
+		},
+	}
+}
+
+</script>


### PR DESCRIPTION
closes #907, closes #691 

What is left to do:
- ~~Easy way to clear all temporary highlights for end user, right now you need to manually toggle all highlights or delete the `chat.filtering.highlight-temp` from localStorage.~~

Optional stuff (nice to have)
- Customizable color for these types of highlights (unless the generic color is sufficient)
- Toggle icon based on if a user is already in the highlight list or not (if it can be done in a performant way)

[Preview video](https://imgur.com/OsVZi5L)