### PR TITLE
Fix date string in settings backup file name

### DIFF
--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -389,7 +389,7 @@ export default class SettingsManager extends Module {
 
 	async generateBackupFile() {
 		const now = new Date(),
-			timestamp = `${now.getFullYear()}-${now.getMonth()}-${now.getDate()}`;
+			timestamp = `${now.getFullYear()}-${now.getMonth() + 1}-${now.getDate()}`;
 
 		if ( await this._needsZipBackup() ) {
 			const blob = await this._getZipBackup();


### PR DESCRIPTION
Fixes issue where the month in the settings backup file name is off by one.

Reason: JavaScript month index is 0-based Sadge.