### PR TITLE
Fix "Show metadata when mousing over the player"

### DIFF
--- a/src/sites/twitch-twilight/modules/css_tweaks/styles/portrait-metadata-top.scss
+++ b/src/sites/twitch-twilight/modules/css_tweaks/styles/portrait-metadata-top.scss
@@ -1,5 +1,5 @@
 .channel-root__scroll-area--theatre-mode {
-	.channel-info-content > div:first-child {
+	.channel-info-content > :first-child {
 		right: 40rem !important;
 		bottom: calc(10rem + var(--ffz-chat-height)) !important;
 	}

--- a/src/sites/twitch-twilight/modules/css_tweaks/styles/theatre-metadata.scss
+++ b/src/sites/twitch-twilight/modules/css_tweaks/styles/theatre-metadata.scss
@@ -1,5 +1,5 @@
 .channel-root__scroll-area--theatre-mode {
-	.channel-info-content > div:first-child,
+	.channel-info-content > :first-child,
 	.channel-info-bar {
 		position: fixed;
 		bottom: 17rem;
@@ -24,7 +24,7 @@
 	}
 
 	&:hover {
-		.channel-info-content > div:first-child,
+		.channel-info-content > :first-child,
 		.channel-info-bar {
 			background-color: var(--color-background-base);
 			opacity: 0.75;


### PR DESCRIPTION
The channel info bar is now a `<section>` element instead of `<div>` so the previous 
`.channel-info-content > div:first-child` css was no longer matching.

We could use the element id `#live-channel-stream-information` instead of `.channel-info-content > :first-child`, 
let me know if I should change it.

I'm not sure if the positioning is correct, seems to be extra space on the right  and below but maybe that is intended?

fixes #1252, fixes #1258