### PR TITLE
getEmoteSuggestions no longer uses stale channel info

### DIFF
--- a/src/sites/twitch-twilight/modules/chat/input.jsx
+++ b/src/sites/twitch-twilight/modules/chat/input.jsx
@@ -942,18 +942,18 @@ export default class Input extends Module {
 
 
 	getEmoteSuggestions(input, inst) {
+		if ( ! inst._ffz_channel_login ) {
+			const parent = this.fine.searchParent(inst, 'chat-input', 50);
+			if ( parent )
+				this.updateEmoteCompletion(parent, inst);
+		}
+
 		const user = inst._ffz_user,
 			channel_id = inst._ffz_channel_id,
 			channel_login = inst._ffz_channel_login;
 
-		if ( ! channel_login ) {
-			const parent = this.fine.searchParent(inst, 'chat-input', 50);
-			if ( parent )
-				this.updateEmoteCompletion(parent, inst);
-
-			if ( ! channel_login )
-				return [];
-		}
+		if ( ! channel_login )
+			return [];
 
 		let cache = inst.ffz_ffz_cache;
 		if ( ! cache || cache.user_id !== user?.id || cache.user_login !== user?.login || cache.channel_id !== channel_id || cache.channel_login !== channel_login )


### PR DESCRIPTION
Fixes #1299 *("After switching channels, the first tab-completion will exclude 3rd-party emotes")*

In some circumstances, `Input.getEmoteSuggestions` will call `updateEmoteCompletion` to refresh certain information about the current channel. When this happens, the local variable `channel_login` is not updated with this new information. As a result, the rest of the function call uses a stale value of `channel_login`. This staleness leads to the issue with tab-completion referenced above. 

This pull request fixes this behavior by moving the call to `updateEmoteCompletion` to before the declaration/assignment of `channel_login`. 