### PR TITLE
The Drops user itself is also a "bad user"

### DIFF
--- a/src/modules/chat/link_providers.js
+++ b/src/modules/chat/link_providers.js
@@ -11,7 +11,7 @@ const USER_URL = /^(?:https?:\/\/)?(?:www\.)?twitch\.tv\/([^/]+)$/;
 
 const BAD_USERS = [
 	'directory', '_deck', 'p', 'downloads', 'jobs', 'turbo', 'settings', 'friends',
-	'subscriptions', 'inventory', 'wallet'
+	'subscriptions', 'drops', 'inventory', 'wallet'
 ];
 
 import GET_CLIP from './clip_info.gql';


### PR DESCRIPTION
The drops user is also a "bad user" and shouldn't draw the "user box"
It's the "friend" page of /inventory.

![image](https://user-images.githubusercontent.com/20999/208719577-4771d946-4a48-4730-9e59-3df7c4c223df.png)
