### PR TITLE
Less strict tab completion. Matches all emotes that contain user input.

### DIFF
--- a/src/sites/twitch-twilight/modules/chat/input.jsx
+++ b/src/sites/twitch-twilight/modules/chat/input.jsx
@@ -19,9 +19,10 @@ const localeCaseInsensitive = Intl.Collator(undefined, {sensitivity: 'accent'});
 // Describes how an emote matches against a given input
 // Higher values represent a more exact match
 const NO_MATCH = 0;
-const NON_PREFIX_MATCH = 1;
-const CASE_INSENSITIVE_PREFIX_MATCH = 2;
-const EXACT_PREFIX_MATCH = 3;
+const SUBSTRING_MATCH = 1;
+const NON_PREFIX_MATCH = 2;
+const CASE_INSENSITIVE_PREFIX_MATCH = 3;
+const EXACT_PREFIX_MATCH = 4;
 
 function getNodeText(node) {
 	if ( ! node )
@@ -828,6 +829,9 @@ export default class Input extends Module {
 			const idx = emote_name.indexOf(term.charAt(0).toUpperCase());
 			if (idx !== -1 && emote_lower.slice(idx + 1).startsWith(term_lower.slice(1)))
 				return NON_PREFIX_MATCH;
+
+			if (emote_lower.includes(term_lower))
+				return SUBSTRING_MATCH;
 
 			return NO_MATCH;
 		}

--- a/src/sites/twitch-twilight/modules/chat/input.jsx
+++ b/src/sites/twitch-twilight/modules/chat/input.jsx
@@ -19,10 +19,9 @@ const localeCaseInsensitive = Intl.Collator(undefined, {sensitivity: 'accent'});
 // Describes how an emote matches against a given input
 // Higher values represent a more exact match
 const NO_MATCH = 0;
-const SUBSTRING_MATCH = 1;
-const NON_PREFIX_MATCH = 2;
-const CASE_INSENSITIVE_PREFIX_MATCH = 3;
-const EXACT_PREFIX_MATCH = 4;
+const NON_PREFIX_MATCH = 1;
+const CASE_INSENSITIVE_PREFIX_MATCH = 2;
+const EXACT_PREFIX_MATCH = 3;
 
 function getNodeText(node) {
 	if ( ! node )
@@ -826,12 +825,8 @@ export default class Input extends Module {
 			if (emote_lower.startsWith(term_lower))
 				return CASE_INSENSITIVE_PREFIX_MATCH;
 
-			const idx = emote_name.indexOf(term.charAt(0).toUpperCase());
-			if (idx !== -1 && emote_lower.slice(idx + 1).startsWith(term_lower.slice(1)))
-				return NON_PREFIX_MATCH;
-
 			if (emote_lower.includes(term_lower))
-				return SUBSTRING_MATCH;
+				return NON_PREFIX_MATCH;
 
 			return NO_MATCH;
 		}

--- a/src/sites/twitch-twilight/modules/chat/input.jsx
+++ b/src/sites/twitch-twilight/modules/chat/input.jsx
@@ -18,10 +18,15 @@ const localeCaseInsensitive = Intl.Collator(undefined, {sensitivity: 'accent'});
 
 // Describes how an emote matches against a given input
 // Higher values represent a more exact match
-const NO_MATCH = 0;
-const NON_PREFIX_MATCH = 1;
-const CASE_INSENSITIVE_PREFIX_MATCH = 2;
-const EXACT_PREFIX_MATCH = 3;
+const NO_MATCH = 0; // Search term doesn't exist in the emote's name
+const SUBSTRING_MATCH = 1; // Term exists somewhere in the emote's name
+const CAPITALIZED_SECTION_MATCH = 2; // Term exists at the start of a capitalized section in the emote
+const CASE_INSENSITIVE_PREFIX_MATCH = 3; // Term characters exist at the start of the emote's name
+const EXACT_PREFIX_MATCH = 4; // Term characters and casing exactly match the start of the emote
+
+function isUpperChar(char) {
+	return (char.length === 1) && (char !== char.toLocaleLowerCase());
+}
 
 function getNodeText(node) {
 	if ( ! node )
@@ -820,13 +825,17 @@ export default class Input extends Module {
 			let emote_lower = emote.tokenLower;
 			if ( ! emote_lower )
 				emote_lower = emote_name.toLowerCase();
-
 			const term_lower = term.toLowerCase();
-			if (emote_lower.startsWith(term_lower))
+			const termPosition = emote_lower.search(term_lower);
+			
+			if (termPosition == 0)
 				return CASE_INSENSITIVE_PREFIX_MATCH;
 
-			if (emote_lower.includes(term_lower))
-				return NON_PREFIX_MATCH;
+			if (isUpperChar(emote_name.charAt(termPosition)))
+				return CAPITALIZED_SECTION_MATCH;
+
+			if (termPosition != -1)
+				return SUBSTRING_MATCH;
 
 			return NO_MATCH;
 		}
@@ -911,24 +920,11 @@ export default class Input extends Module {
 					else return 0 - bIsEmoji + aIsEmoji;
 				}
 
-				// Prefer case-sensitive prefix matches
-				const aStartsWithInput = (a.match_type === EXACT_PREFIX_MATCH);
-				const bStartsWithInput = (b.match_type === EXACT_PREFIX_MATCH);
-				if (aStartsWithInput && bStartsWithInput)
+				// Prefer highest match priority, then sort alphabetically
+				if (a.match_type !== b.match_type)
+					return b.match_type - a.match_type;
+				else
 					return locale.compare(aStr, bStr);
-				else if (aStartsWithInput) return -1;
-				else if (bStartsWithInput) return 1;
-
-				// Else prefer case-insensitive prefix matches
-				const aStartsWithInputCI = (a.match_type === CASE_INSENSITIVE_PREFIX_MATCH);
-				const bStartsWithInputCI = (b.match_type === CASE_INSENSITIVE_PREFIX_MATCH);
-				if (aStartsWithInputCI && bStartsWithInputCI)
-					return localeCaseInsensitive.compare(aStr, bStr);
-				else if (aStartsWithInputCI) return -1;
-				else if (bStartsWithInputCI) return 1;
-
-				// Else alphabetize
-				return locale.compare(aStr, bStr);
 			}
 
 			// Keep unsorted order for non-favorite items if prefix matching is not enabled.
@@ -1028,7 +1024,8 @@ export default class Input extends Module {
 			return [];
 
 		const results_usage = [],
-			results_starting = [],
+			results_prefix = [],
+			results_capitalized = [],
 			results_other = [],
 
 			search = input.startsWith(':') ? input.slice(1) : input;
@@ -1048,18 +1045,21 @@ export default class Input extends Module {
 
 				if ( element.count > 0 )
 					results_usage.push(element);
-				else if ( match_type > NON_PREFIX_MATCH )
-					results_starting.push(element);
+				else if ( match_type >= CASE_INSENSITIVE_PREFIX_MATCH )
+					results_prefix.push(element);
+				else if ( match_type == CAPITALIZED_SECTION_MATCH )
+					results_capitalized.push(element);
 				else
 					results_other.push(element);
 			}
 		}
 
 		results_usage.sort((a,b) => b.count - a.count);
-		results_starting.sort((a,b) => locale.compare(a.replacement, b.replacement));
+		results_prefix.sort((a,b) => locale.compare(a.replacement, b.replacement));
+		results_capitalized.sort((a,b) => locale.compare(a.replacement, b.replacement));
 		results_other.sort((a,b) => locale.compare(a.replacement, b.replacement));
 
-		return results_usage.concat(results_starting).concat(results_other);
+		return results_usage.concat(results_prefix).concat(results_capitalized).concat(results_other);
 	}
 
 

--- a/src/sites/twitch-twilight/modules/chat/input.jsx
+++ b/src/sites/twitch-twilight/modules/chat/input.jsx
@@ -828,13 +828,13 @@ export default class Input extends Module {
 			const term_lower = term.toLowerCase();
 			const termPosition = emote_lower.search(term_lower);
 			
-			if (termPosition == 0)
+			if (termPosition === 0)
 				return CASE_INSENSITIVE_PREFIX_MATCH;
 
 			if (isUpperChar(emote_name.charAt(termPosition)))
 				return CAPITALIZED_SECTION_MATCH;
 
-			if (termPosition != -1)
+			if (termPosition !== -1)
 				return SUBSTRING_MATCH;
 
 			return NO_MATCH;
@@ -1047,7 +1047,7 @@ export default class Input extends Module {
 					results_usage.push(element);
 				else if ( match_type >= CASE_INSENSITIVE_PREFIX_MATCH )
 					results_prefix.push(element);
-				else if ( match_type == CAPITALIZED_SECTION_MATCH )
+				else if ( match_type === CAPITALIZED_SECTION_MATCH )
 					results_capitalized.push(element);
 				else
 					results_other.push(element);


### PR DESCRIPTION
Tab completion will now offer emotes that match the typed sequence as long as it appears anywhere in the emote's name. Previously it would only offer emotes if the term existed at the start of the emote name, or at a capital letter.

Example before:
![image](https://user-images.githubusercontent.com/10762433/230698658-73080af0-6e4f-4be2-86e6-6f1d3434fe16.png)

Example after:
![image](https://user-images.githubusercontent.com/10762433/230698675-440471a7-8cd1-4bc2-bdb8-f66df0b243b9.png)


Should close #1327 