### PR TITLE
Fix autocomplete not showing all emotes

### DIFF
--- a/src/sites/twitch-twilight/modules/chat/input.jsx
+++ b/src/sites/twitch-twilight/modules/chat/input.jsx
@@ -19,9 +19,10 @@ const localeCaseInsensitive = Intl.Collator(undefined, {sensitivity: 'accent'});
 // Describes how an emote matches against a given input
 // Higher values represent a more exact match
 const NO_MATCH = 0;
-const NON_PREFIX_MATCH = 1;
-const CASE_INSENSITIVE_PREFIX_MATCH = 2;
-const EXACT_PREFIX_MATCH = 3;
+const CASE_INSENSITIVE_NON_PREFIX_MATCH = 1;
+const NON_PREFIX_MATCH = 2;
+const CASE_INSENSITIVE_PREFIX_MATCH = 3;
+const EXACT_PREFIX_MATCH = 4;
 
 function getNodeText(node) {
 	if ( ! node )
@@ -869,6 +870,9 @@ export default class Input extends Module {
 			const idx = emote_name.indexOf(term.charAt(0).toUpperCase());
 			if (idx !== -1 && emote_lower.slice(idx + 1).startsWith(term_lower.slice(1)))
 				return NON_PREFIX_MATCH;
+
+			if (emote_lower.includes(term_lower))
+				return CASE_INSENSITIVE_NON_PREFIX_MATCH;
 
 			return NO_MATCH;
 		}


### PR DESCRIPTION
Closes #1374.

Not sure why, but with FFZ emote autocomplete not showing all emotes.

Original twitch behavior:
![image](https://github.com/FrankerFaceZ/FrankerFaceZ/assets/8844478/fb20b111-8ea3-4764-966c-2622e93b3227)

With FFZ:
![image](https://github.com/FrankerFaceZ/FrankerFaceZ/assets/8844478/d903a1bf-b229-42e6-9223-9d42e58b0879)

After the fix:
![image](https://github.com/FrankerFaceZ/FrankerFaceZ/assets/8844478/5567b9e6-0927-4007-a383-6b1b673fea85)
