### PR TITLE
Add urlencode formatter and add formatter list to more actions

### DIFF
--- a/src/modules/chat/actions/components/edit-copy.vue
+++ b/src/modules/chat/actions/components/edit-copy.vue
@@ -16,6 +16,10 @@
 			<div class="tw-c-text-alt-2 tw-mg-b-1">
 				{{ t('setting.actions.variables', 'Available Variables: {vars}', {vars}) }}
 			</div>
+
+			<div class="tw-c-text-alt-2 tw-mg-b-1">
+				{{ t('setting.actions.formats', 'Available Formatters: {fmts}', {fmts}) }}
+			</div>
 		</div>
 	</div>
 </template>
@@ -23,7 +27,7 @@
 <script>
 
 export default {
-	props: ['value', 'defaults', 'vars'],
+	props: ['value', 'defaults', 'vars', 'fmts'],
 }
 
 </script>

--- a/src/modules/chat/actions/components/edit-url.vue
+++ b/src/modules/chat/actions/components/edit-url.vue
@@ -16,6 +16,10 @@
 			<div class="tw-c-text-alt-2 tw-mg-b-1">
 				{{ t('setting.actions.variables', 'Available Variables: {vars}', {vars}) }}
 			</div>
+
+			<div class="tw-c-text-alt-2 tw-mg-b-1">
+				{{ t('setting.actions.formats', 'Available Formatters: {fmts}', {fmts}) }}
+			</div>
 		</div>
 	</div>
 </template>
@@ -23,7 +27,7 @@
 <script>
 
 export default {
-	props: ['value', 'defaults', 'vars'],
+	props: ['value', 'defaults', 'vars', 'fmts'],
 }
 
 </script>

--- a/src/modules/chat/actions/index.jsx
+++ b/src/modules/chat/actions/index.jsx
@@ -320,6 +320,9 @@ export default class Actions extends Module {
 				slugify(val, locale, options, extra) {
 					return val.toString().toSlug(extra && extra.length ? extra : '-');
 				},
+				urlencode(val) {
+					return encodeURIComponent(val);
+				},
 				word(val, locale, options, extra) {
 					if (! extra || ! extra.length)
 						return val;

--- a/src/modules/main_menu/components/action-editor.vue
+++ b/src/modules/main_menu/components/action-editor.vue
@@ -509,6 +509,7 @@ export default {
 			out.push('snakecase');
 			out.push('slugify');
 			out.push('slugify(separator)');
+			out.push('urlencode');
 
 			return out.join(', ');
 		},


### PR DESCRIPTION
I propose the chat action formatter "urlencode". I've also added the formatter list to more actions. I was confused when it wasn't there for an Open URL action, and I could have sworn there were text formatters available. If there's documentation on using formatters, I cannot find it at a glance. I remember it from looking at the regex in the source.

# Use case

If I want to have an action that opens a URL to Google Translate, I need to make sure characters like "&" are encoded but that's not available yet.

For instance this formattable URL with `urlencode` in use:
```
https://translate.google.com/?sl=auto&tl=auto&text={{message.text|urlencode}}&op=translate
```

Example action JSON:
```json
{"action":"open_url","appearance":{"type":"icon","icon":"ffz-i-language","tooltip":"Google Translate"},"options":{"url":"https://translate.google.com/?sl=auto&tl=auto&text={{message.text|urlencode}}&op=translate"},"display":{}}
```

![image](https://github.com/FrankerFaceZ/FrankerFaceZ/assets/7132646/b64ffbe4-5a32-4368-b21e-0e04df49ac03)

# Name choice

## `URL` vs `URI`

The lay person doesn't care to distinguish them, so the most obvious one was chosen.

## `urlencode` vs `encodeurl`

Since all of the formatters are presented all lowercase, "url" first is easier to spot.