### PR TITLE
Fix for randomly oversized emojis for some users

### DIFF
--- a/src/sites/clips/styles/clips-main.scss
+++ b/src/sites/clips/styles/clips-main.scss
@@ -22,8 +22,8 @@
 }
 
 .ffz-emoji {
-	width: calc(var(--ffz-chat-font-size) * 1.5);
-	height: calc(var(--ffz-chat-font-size) * 1.5);
+	width: calc(var(--ffz-chat-font-size, 1em) * 1.5);
+	height: calc(var(--ffz-chat-font-size, 1em) * 1.5);
 
 	&.preview-image {
 		width: 7.2rem;

--- a/src/sites/twitch-twilight/modules/css_tweaks/styles/big-emoji.scss
+++ b/src/sites/twitch-twilight/modules/css_tweaks/styles/big-emoji.scss
@@ -1,6 +1,6 @@
 .ffz--inline:not(.scaled-modified-emote) .ffz-emoji {
 	width: 3.6rem !important;
 	height: 3.6rem !important;
-	width: calc(var(--ffz-chat-font-size) * 3) !important;
-	height: calc(var(--ffz-chat-font-size) * 3) !important;
+	width: calc(var(--ffz-chat-font-size, 1em) * 3) !important;
+	height: calc(var(--ffz-chat-font-size, 1em) * 3) !important;
 }

--- a/src/sites/twitch-twilight/styles/chat.scss
+++ b/src/sites/twitch-twilight/styles/chat.scss
@@ -165,8 +165,8 @@
 .ffz-notice-icon,
 .ffz-emoji {
 	width: 1.8rem; height: 1.8rem;
-	width: calc(var(--ffz-chat-font-size) * 1.5);
-	height: calc(var(--ffz-chat-font-size) * 1.5);
+	width: calc(var(--ffz-chat-font-size, 1em) * 1.5);
+	height: calc(var(--ffz-chat-font-size, 1em) * 1.5);
 }
 
 .ffz-emoji {


### PR DESCRIPTION
Gave the css variable --ffz-chat-font-size a default value of 1em whenever it deals with emojis. the emojis should be displaced inline with the other text anyways so whenever it can't find --ffz-chat-font-size 1em ("current font-size") should work just as well. This should remove the issue that users have with random huge default-emojis.