### PR TITLE
add toggle to hide gift sub buttons

### DIFF
--- a/src/sites/twitch-twilight/modules/css_tweaks/index.js
+++ b/src/sites/twitch-twilight/modules/css_tweaks/index.js
@@ -481,6 +481,18 @@ export default class CSSTweaks extends Module {
 			changed: val => this.toggle('square-avatars', !val)
 		});
 
+		this.settings.add('channel.gift-sub-buttons.hide', {
+			default: false,
+			ui: {
+				order: -1,
+				path: 'Channel > Appearance >> General',
+				title: 'Hide the sub gifting buttons in the channel header and channel goals.',
+				description: 'Note: This will not hide sub gifting buttons in chat.',
+				component: 'setting-check-box'
+			},
+			changed: val => this.toggle('hide-channel-gift-sub-buttons', val)
+		});
+
 		/*this.settings.add('channel.hide-not-live-bar', {
 			default: false,
 			ui: {
@@ -515,6 +527,7 @@ export default class CSSTweaks extends Module {
 		this.toggleHide('pinned-hype-chat', ! this.settings.get('chat.hype.show-pinned'));
 
 		this.toggle('square-avatars', ! this.settings.get('channel.round-avatars'));
+		this.toggle('hide-channel-gift-sub-buttons', this.settings.get('channel.gift-sub-buttons.hide'));
 		//this.toggleHide('not-live-bar', this.settings.get('channel.hide-not-live-bar'));
 		this.toggleHide('channel-live-ind', this.settings.get('channel.hide-live-indicator'));
 

--- a/src/sites/twitch-twilight/modules/css_tweaks/index.js
+++ b/src/sites/twitch-twilight/modules/css_tweaks/index.js
@@ -49,6 +49,7 @@ const CLASSES = {
 	'profile-hover': '.preview-card .tw-relative:hover .ffz-channel-avatar',
 	'not-live-bar': 'div[data-test-selector="non-live-video-banner-layout"]',
 	'channel-live-ind': '.channel-header__user .tw-channel-status-text-indicator,.channel-info-content .tw-halo__indicator',
+	'channel-gift-sub-buttons': '.channel-info-content button[data-a-target="gift-button"]',
 	'celebration': 'body .celebration__overlay',
 
 	'last-x-events': '.last-x-events_container',
@@ -484,13 +485,12 @@ export default class CSSTweaks extends Module {
 		this.settings.add('channel.gift-sub-buttons.hide', {
 			default: false,
 			ui: {
-				order: -1,
 				path: 'Channel > Appearance >> General',
 				title: 'Hide the sub gifting buttons in the channel header and channel goals.',
 				description: 'Note: This will not hide sub gifting buttons in chat.',
 				component: 'setting-check-box'
 			},
-			changed: val => this.toggle('hide-channel-gift-sub-buttons', val)
+			changed: val => this.toggleHide('channel-gift-sub-buttons', val)
 		});
 
 		/*this.settings.add('channel.hide-not-live-bar', {
@@ -527,7 +527,7 @@ export default class CSSTweaks extends Module {
 		this.toggleHide('pinned-hype-chat', ! this.settings.get('chat.hype.show-pinned'));
 
 		this.toggle('square-avatars', ! this.settings.get('channel.round-avatars'));
-		this.toggle('hide-channel-gift-sub-buttons', this.settings.get('channel.gift-sub-buttons.hide'));
+		this.toggleHide('channel-gift-sub-buttons', this.settings.get('channel.gift-sub-buttons.hide'));
 		//this.toggleHide('not-live-bar', this.settings.get('channel.hide-not-live-bar'));
 		this.toggleHide('channel-live-ind', this.settings.get('channel.hide-live-indicator'));
 

--- a/src/sites/twitch-twilight/modules/css_tweaks/styles/hide-channel-gift-sub-buttons.scss
+++ b/src/sites/twitch-twilight/modules/css_tweaks/styles/hide-channel-gift-sub-buttons.scss
@@ -1,3 +1,0 @@
-button[data-a-target="gift-button"] {
-	display: none !important;
-}

--- a/src/sites/twitch-twilight/modules/css_tweaks/styles/hide-channel-gift-sub-buttons.scss
+++ b/src/sites/twitch-twilight/modules/css_tweaks/styles/hide-channel-gift-sub-buttons.scss
@@ -1,0 +1,3 @@
+button[data-a-target="gift-button"] {
+	display: none !important;
+}


### PR DESCRIPTION
adds a toggle under `Channel > Appearance >> General` to hide the "gift a sub" buttons from the channel header (right under the player) and from the channel goals.

because i have poor impulse control sometimes

<3 tyvm; i love the extension

## normal (default; no change)
<img width="439" alt="Screenshot 2025-05-26 at 01 10 28" src="https://github.com/user-attachments/assets/a8581dc6-13cf-4be2-b135-1c971ee7d5a4" />

## with the new setting checked
<img width="412" alt="Screenshot 2025-05-26 at 01 10 51" src="https://github.com/user-attachments/assets/24aa2964-5709-40a6-a6aa-30e577ac48e7" />

