### PR TITLE
add two options to hide player overlays

### DIFF
--- a/src/sites/twitch-twilight/modules/css_tweaks/index.js
+++ b/src/sites/twitch-twilight/modules/css_tweaks/index.js
@@ -39,6 +39,7 @@ const CLASSES = {
 	'player-ext-hover': '.video-player__container[data-controls="false"] .extension-taskbar,.video-player__container[data-controls="false"] .extension-container,.video-player__container[data-controls="false"] .extensions-dock__layout,.video-player__container[data-controls="false"] .extensions-notifications,.video-player__container[data-controls="false"] .extensions-video-overlay-size-container',
 	'player-cast': '.video-player button:has(.tw-chromecast-button__icon)',
 	'player-extensions-overlay': '.video-player .video-player__overlay .extensions-dock__dock',
+	'player-prime-benefits': '.video-player .extensions-video-overlay-size-container div[data-test-selector="iframe_container_selector"] iframe.extension-view__iframe',
 
 	'player-event-bar': '.channel-root .live-event-banner-ui__header',
 	'player-rerun-bar': '.channel-root__player-container div.tw-c-text-overlay:not([data-a-target="hosting-ui-header"])',

--- a/src/sites/twitch-twilight/modules/css_tweaks/index.js
+++ b/src/sites/twitch-twilight/modules/css_tweaks/index.js
@@ -38,6 +38,7 @@ const CLASSES = {
 	'player-ext': '.video-player .extension-taskbar,.video-player .extension-container,.video-player .extensions-dock__layout,.video-player .extensions-notifications,.video-player .extensions-video-overlay-size-container,.video-player .extensions-dock__layout',
 	'player-ext-hover': '.video-player__container[data-controls="false"] .extension-taskbar,.video-player__container[data-controls="false"] .extension-container,.video-player__container[data-controls="false"] .extensions-dock__layout,.video-player__container[data-controls="false"] .extensions-notifications,.video-player__container[data-controls="false"] .extensions-video-overlay-size-container',
 	'player-cast': '.video-player button:has(.tw-chromecast-button__icon)',
+	'player-extensions-overlay': '.video-player .video-player__overlay .extensions-dock__dock',
 
 	'player-event-bar': '.channel-root .live-event-banner-ui__header',
 	'player-rerun-bar': '.channel-root__player-container div.tw-c-text-overlay:not([data-a-target="hosting-ui-header"])',

--- a/src/sites/twitch-twilight/modules/css_tweaks/styles/player-extensions-overlay.scss
+++ b/src/sites/twitch-twilight/modules/css_tweaks/styles/player-extensions-overlay.scss
@@ -1,4 +1,0 @@
-.extensions-dock__dock {
-	display: none !important;
-}
-

--- a/src/sites/twitch-twilight/modules/css_tweaks/styles/player-extensions-overlay.scss
+++ b/src/sites/twitch-twilight/modules/css_tweaks/styles/player-extensions-overlay.scss
@@ -1,0 +1,4 @@
+.extensions-dock__dock {
+	display: none !important;
+}
+

--- a/src/sites/twitch-twilight/modules/player.jsx
+++ b/src/sites/twitch-twilight/modules/player.jsx
@@ -166,10 +166,10 @@ export default class Player extends PlayerBase {
 			ui: {
 				path: 'Player > General >> Appearance',
 				component: 'setting-check-box',
-				title: 'Hide the extensions dock overlay.',
+				title: 'Hide the extensions dock overlay that pops up on hover.',
 			},
 
-			changed: val => this.css_tweaks.toggle('player-extensions-overlay', val)
+			changed: val => this.css_tweaks.toggleHide('player-extensions-overlay', val)
 		});
 
 		/*this.settings.add('player.hide-rerun-bar', {
@@ -193,7 +193,7 @@ export default class Player extends PlayerBase {
 
 		this.css_tweaks.toggle('theatre-no-whispers', this.settings.get('player.theatre.no-whispers'));
 		this.css_tweaks.toggle('theatre-metadata', this.settings.get('player.theatre.metadata'));
-		this.css_tweaks.toggle('player-extensions-overlay', this.settings.get('player.extensions-overlay.hide'));
+		this.css_tweaks.toggleHide('player-extensions-overlay', this.settings.get('player.extensions-overlay.hide'));
 		this.css_tweaks.toggleHide('player-event-bar', this.settings.get('player.hide-event-bar'));
 		//this.css_tweaks.toggleHide('player-rerun-bar', this.settings.get('player.hide-rerun-bar'));
 

--- a/src/sites/twitch-twilight/modules/player.jsx
+++ b/src/sites/twitch-twilight/modules/player.jsx
@@ -172,6 +172,17 @@ export default class Player extends PlayerBase {
 			changed: val => this.css_tweaks.toggleHide('player-extensions-overlay', val)
 		});
 
+		this.settings.add('player.prime-benefits.hide', {
+			default: false,
+			ui: {
+				path: 'Player > General >> Appearance',
+				component: 'setting-check-box',
+				title: 'Hide the Prime Benefits dropdown button in the player overlay.',
+			},
+
+			changed: val => this.css_tweaks.toggleHide('player-prime-benefits', val)
+		});
+
 		/*this.settings.add('player.hide-rerun-bar', {
 			default: false,
 			ui: {
@@ -194,6 +205,7 @@ export default class Player extends PlayerBase {
 		this.css_tweaks.toggle('theatre-no-whispers', this.settings.get('player.theatre.no-whispers'));
 		this.css_tweaks.toggle('theatre-metadata', this.settings.get('player.theatre.metadata'));
 		this.css_tweaks.toggleHide('player-extensions-overlay', this.settings.get('player.extensions-overlay.hide'));
+		this.css_tweaks.toggleHide('player-prime-benefits', this.settings.get('player.prime-benefits.hide'));
 		this.css_tweaks.toggleHide('player-event-bar', this.settings.get('player.hide-event-bar'));
 		//this.css_tweaks.toggleHide('player-rerun-bar', this.settings.get('player.hide-rerun-bar'));
 

--- a/src/sites/twitch-twilight/modules/player.jsx
+++ b/src/sites/twitch-twilight/modules/player.jsx
@@ -161,6 +161,17 @@ export default class Player extends PlayerBase {
 			}
 		});
 
+		this.settings.add('player.extensions-overlay.hide', {
+			default: false,
+			ui: {
+				path: 'Player > General >> Appearance',
+				component: 'setting-check-box',
+				title: 'Hide the extensions dock overlay.',
+			},
+
+			changed: val => this.css_tweaks.toggle('player-extensions-overlay', val)
+		});
+
 		/*this.settings.add('player.hide-rerun-bar', {
 			default: false,
 			ui: {
@@ -182,6 +193,7 @@ export default class Player extends PlayerBase {
 
 		this.css_tweaks.toggle('theatre-no-whispers', this.settings.get('player.theatre.no-whispers'));
 		this.css_tweaks.toggle('theatre-metadata', this.settings.get('player.theatre.metadata'));
+		this.css_tweaks.toggle('player-extensions-overlay', this.settings.get('player.extensions-overlay.hide'));
 		this.css_tweaks.toggleHide('player-event-bar', this.settings.get('player.hide-event-bar'));
 		//this.css_tweaks.toggleHide('player-rerun-bar', this.settings.get('player.hide-rerun-bar'));
 


### PR DESCRIPTION
adds two options (disabled by default) to hide player overlays that appear on hover:

1. the Prime Benefits dropdown box
2. the extensions dock

some streamers use the extensions dock, so imo these options should be separate.

Both of the toggles are under `Player > General >> Appearance`

default behavior:
![hide-overlay-default](https://github.com/user-attachments/assets/d273b465-72da-4ced-849c-77a963873efe)

toggles enabled:
![hide-overlays-enabled](https://github.com/user-attachments/assets/7b1bc584-a1a2-41a8-9f5f-e27128078832)


