### PR TITLE
bugfix: fix css selector for top nav get bits button

### DIFF
--- a/src/sites/twitch-twilight/modules/css_tweaks/styles/hide-bits.scss
+++ b/src/sites/twitch-twilight/modules/css_tweaks/styles/hide-bits.scss
@@ -1,7 +1,7 @@
 .get-bits-button,
 .gem-notif-icon,
 .chat-input button[data-a-target="bits-button"],
-button[data-test-selector="get-bits-button__top-nav-button"],
+button[data-a-target="top-nav-get-bits-button"],
 .channel-header__right > .tw-mg-l-1 > div > div > button:not([data-a-target]) {
 	display: none !important;
 }


### PR DESCRIPTION
currently, the Get Bits button is still shown when unchecking 'Display Bits' under Chat > Bits and Cheering >> Appearance. it looks like attributes changed & it no longer has `data-test-selector`. updated to use `data-a-target="top-nav-get-bits-button"`

note: i couldn't get the 'Show the Get Bits button.' option under Apperance > Layout >> Top Navigation to work independently of the option under Chat > Bits and Cheering. not sure what's up with that.

on master:
<img width="1074" alt="Screenshot 2025-05-28 at 23 42 21" src="https://github.com/user-attachments/assets/2d389719-d493-4248-8f06-065adc94fdac" />

on 🍋/bugfix-show-get-bits-button:
<img width="1089" alt="Screenshot 2025-05-28 at 23 43 31" src="https://github.com/user-attachments/assets/38993983-e546-463b-9309-097daa722d06" />
