### PR TITLE
feat: add a toggle to hide combos

### DIFF
--- a/src/sites/twitch-twilight/modules/css_tweaks/index.js
+++ b/src/sites/twitch-twilight/modules/css_tweaks/index.js
@@ -38,6 +38,7 @@ const CLASSES = {
 	'player-ext': '.video-player .extension-taskbar,.video-player .extension-container,.video-player .extensions-dock__layout,.video-player .extensions-notifications,.video-player .extensions-video-overlay-size-container,.video-player .extensions-dock__layout',
 	'player-ext-hover': '.video-player__container[data-controls="false"] .extension-taskbar,.video-player__container[data-controls="false"] .extension-container,.video-player__container[data-controls="false"] .extensions-dock__layout,.video-player__container[data-controls="false"] .extensions-notifications,.video-player__container[data-controls="false"] .extensions-video-overlay-size-container',
 	'player-cast': '.video-player button:has(.tw-chromecast-button__icon)',
+	'combos': 'div:has(> [aria-controls="one-tap-store-id"]), div > div > .tw-transition-group:has([class*="oneTapStreakPill--"]), div#one-tap-store-id',
 
 	'player-event-bar': '.channel-root .live-event-banner-ui__header',
 	'player-rerun-bar': '.channel-root__player-container div.tw-c-text-overlay:not([data-a-target="hosting-ui-header"])',
@@ -343,6 +344,16 @@ export default class CSSTweaks extends Module {
 			}
 		});
 
+		this.settings.add('layout.combos', {
+			default: false,
+			ui: {
+				path: 'Appearance > Layout >> Channel',
+				title: 'Hide Combos.',
+				component: 'setting-check-box'
+			},
+			changed: val => this.toggleHide('combos', val)
+		});
+
 		/*this.settings.add('layout.discover', {
 			default: true,
 			ui: {
@@ -510,6 +521,7 @@ export default class CSSTweaks extends Module {
 		this.toggleHide('discover-luna', this.settings.get('layout.hide-discover-luna'));
 		this.toggleHide('prime-offers', !this.settings.get('layout.prime-offers'));
 		//this.toggleHide('top-discover', !this.settings.get('layout.discover'));
+		this.toggleHide('combos', this.settings.get('layout.combos'));
 		this.toggle('hide-unfollow-button', this.settings.get('channel.hide-unfollow'));
 
 		this.toggleHide('pinned-hype-chat', ! this.settings.get('chat.hype.show-pinned'));


### PR DESCRIPTION
Closes #1682 

Adds a toggle to hide the new *Combos* menu.

| Before (disabled) | After (enabled) |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/ac318898-6c1f-4af1-8c4e-6ca2e27a32fb) | ![image](https://github.com/user-attachments/assets/4cfb85bd-90d5-44c7-8341-0c02fafbd71b) | 