### PR TITLE
bugfix: fix BTTV and 7TV emote inline preview rendering while "Display Room Actions above the chat input box" is enabled

### DIFF
--- a/src/sites/twitch-twilight/modules/chat/input.jsx
+++ b/src/sites/twitch-twilight/modules/chat/input.jsx
@@ -235,7 +235,14 @@ export default class Input extends Module {
 	async onEnable() {
 		this.chat.context.on('changed:chat.hype.display-input', () => this.ChatInput.forceUpdate());
 		this.chat.context.on('changed:chat.actions.room', () => this.ChatInput.forceUpdate());
-		this.chat.context.on('changed:chat.actions.room-above', () => this.ChatInput.forceUpdate());
+		this.chat.context.on('changed:chat.actions.room-above', () => {
+			this.ChatInput.forceUpdate();
+			if ( this.use_previews )
+				for(const inst of this.ChatInput.instances) {
+					this.removePreviewObserver(inst);
+					this.installPreviewObserver(inst);
+				}
+		});
 		this.chat.context.on('changed:chat.tab-complete.emotes-without-colon', enabled => {
 			for (const inst of this.EmoteSuggestions.instances)
 				inst.canBeTriggeredByTab = enabled;
@@ -417,8 +424,9 @@ export default class Input extends Module {
 		if ( ! this.use_previews )
 			return;
 
-		const el = this.fine.getHostNode(inst),
-			target = el && el.querySelector('.chat-input__textarea');
+		const el = this.fine.getHostNode(inst);
+		const above = this.chat.context.get('chat.actions.room-above');
+		const target = above && el ? el : el.querySelector('.chat-input__textarea');
 		if ( ! target )
 			return;
 

--- a/src/sites/twitch-twilight/modules/chat/input.jsx
+++ b/src/sites/twitch-twilight/modules/chat/input.jsx
@@ -426,7 +426,7 @@ export default class Input extends Module {
 
 		const el = this.fine.getHostNode(inst);
 		const above = this.chat.context.get('chat.actions.room-above');
-		const target = above && el ? el : el.querySelector('.chat-input__textarea');
+		const target = above ? el : el && el.querySelector('.chat-input__textarea');
 		if ( ! target )
 			return;
 


### PR DESCRIPTION
Fixes #1610 

When the setting "Display Room Actions above the chat input box" / chat.actions.room-above is enabled the render call inserts nodes before the `chat-input__textarea` node  which causes it to be replaced as far as I could find out and that causes the MutationObserver to exist on a no longer used / removed node and not updating the the previews anymore.

Now when the setting chat.actions.room-above is set we attach the MutationObserver to the host node (`chat-input`) which does not get replaced.

What I noticed when changing the setting from on to off the remove and install of the observer does not result in it working but after a Page refresh it does work as expected.

Alternatively it is also possible to only attach the observers to the host node (`chat-input`) in both cases (above setting on/off), if that is the preferred solution.

