### PR TITLE
fix: lead moderator badge position

### DIFF
--- a/src/modules/chat/badges.jsx
+++ b/src/modules/chat/badges.jsx
@@ -59,6 +59,7 @@ export const BADGE_POSITIONS = {
 	broadcaster: 0,
 	mod: 1,
 	moderator: 1,
+	lead_moderator: 1,
 	twitchbot: 1,
 	vip: 2,
 	subscriber: 25


### PR DESCRIPTION
Fixes the position of the new **Lead Moderator** badge.

| Before | After |
|--------|--------|
| <img width="214" height="31" src="https://github.com/user-attachments/assets/1b29472f-e6f3-418b-9fbd-4360c3e5be33" /> | <img width="220" height="35" src="https://github.com/user-attachments/assets/99610f6c-fb5e-4f62-90c2-fe686a35a994" /> | 