### PR TITLE
* Fixed: Chat command tab-completion not showing group headers for viewers

### DIFF
--- a/src/sites/twitch-twilight/modules/chat/input.jsx
+++ b/src/sites/twitch-twilight/modules/chat/input.jsx
@@ -837,7 +837,7 @@ export default class Input extends Module {
 					element: inst.renderCommandSuggestion(cmd, i),
 					group: cmd.ffz_group ?
 						(Array.isArray(cmd.ffz_group) ? t.i18n.t(...cmd.ffz_group) : cmd.ffz_group)
-						: inst.determineGroup(cmd),
+						: (inst.determineGroup(cmd) || 'twitch'),
 					selection
 				});
 			}


### PR DESCRIPTION
\* Fixed: Chat command tab-completion not showing group headers for viewers, causing FFZ/addon commands to appear ungrouped

--

When using the tab-completion for chat commands as a regular viewer (not mod/broadcaster), Twitch's native group determination returns `undefined` for viewer commands.

This causes:
- No group headers to display for Twitch's viewer commands (/block, /color, /help, etc.) (probably intended, same behaviour when FFZ is disabled)
- FFZ's own commands appear grouped together with Twitch commands
- If any addons (with ffz_group) are enabled, the FFZ's commands will be grouped correctly, but not the addons

But as a broadcaster/moderator Twitch actually returns proper group names ("channel management", "twitch"), so groups are displayed correctly.

**Fix:**
Fallback to group name "twitch" when `determineGroup(cmd)` returns undefined, ensuring all commands have a group and headers display consistently regardless of user permissions.


```diff
- inst.determineGroup(cmd)
+ (inst.determineGroup(cmd) || 'twitch')
```


As a viewer | Broadcaster/Moderator
--- | --- 
<img width="399" height="689" src="https://github.com/user-attachments/assets/e7051936-f4bf-4094-9b25-9d2a9ab42f0a" /> <img width="398" height="802" src="https://github.com/user-attachments/assets/43bc792f-7fff-420a-8c77-3e1d4cb0cd93" /> | <img width="399" height="950" src="https://github.com/user-attachments/assets/779d5643-0e7f-4726-9528-33fc082968ca" /> <img width="398" height="950" src="https://github.com/user-attachments/assets/70a28b66-11d3-4780-9650-018586d728fb" />
