### PR TITLE
Make Deleted Message styling consistent across chat, viewer cards, and unban appeals

### DIFF
--- a/src/sites/twitch-twilight/modules/chat/index.js
+++ b/src/sites/twitch-twilight/modules/chat/index.js
@@ -1301,6 +1301,7 @@ export default class ChatHook extends Module {
 		this.chat.context.getChanges('chat.filtering.deleted-style', val => {
 			this.css_tweaks.toggle('chat-deleted-strike', val === 1 || val === 2);
 			this.css_tweaks.toggle('chat-deleted-fade', val < 2);
+			this.css_tweaks.toggle('chat-deleted-no-strike', val === 0);
 		});
 
 		this.chat.context.getChanges('chat.filtering.clickable-mentions', val =>

--- a/src/sites/twitch-twilight/modules/css_tweaks/styles/chat-deleted-fade.scss
+++ b/src/sites/twitch-twilight/modules/css_tweaks/styles/chat-deleted-fade.scss
@@ -3,3 +3,7 @@
 		opacity: 0.5;
 	}
 }
+
+.vcml-message:not(:hover) .chat-line__message--deleted > * {
+	opacity: 0.5;
+}

--- a/src/sites/twitch-twilight/modules/css_tweaks/styles/chat-deleted-no-strike.scss
+++ b/src/sites/twitch-twilight/modules/css_tweaks/styles/chat-deleted-no-strike.scss
@@ -1,0 +1,14 @@
+.vcml-message {
+	.chat-line__message--deleted-detailed,
+	.chat-line__message--censored-detailed {
+		text-decoration: none !important;
+		
+		.chat-line__message--emote-button span::before {
+			display: none !important;
+		}
+		
+		img {
+			opacity: 1 !important;
+		}
+	}
+}


### PR DESCRIPTION
Extends the "Detailed Message Style" setting to also affect deleted messages shown in viewer cards and unban appeals.