### PR TITLE
Fix chat font not applying to chat input

### DIFF
--- a/src/sites/twitch-twilight/modules/css_tweaks/styles/chat-font.scss
+++ b/src/sites/twitch-twilight/modules/css_tweaks/styles/chat-font.scss
@@ -12,8 +12,8 @@
 	}
 }
 
-textarea[data-a-target="chat-input"],
-textarea[data-a-target="video-chat-input"] {
+div[data-a-target="chat-input"],
+div[data-a-target="video-chat-input"] {
 	font-family: var(--ffz-chat-font-family) !important;
 	font-size: var(--ffz-chat-font-size) !important;
 }


### PR DESCRIPTION
## Summary

- Twitch replaced the chat input `<textarea>` with a Slate.js `contenteditable` `<div>`, so the `textarea[data-a-target="chat-input"]` selectors in `chat-font.scss` no longer match. Updated them to `div[...]`.

Fixes #1726