### PR TITLE
Add support for Kick streaming platform

### DIFF
--- a/src/entry_ext.js
+++ b/src/entry_ext.js
@@ -4,9 +4,15 @@
 	const browser = globalThis.browser ?? globalThis.chrome;
 	const is_firefox = (typeof browser === 'object' && browser.runtime.getURL('').startsWith('moz'));
 
+	const IS_KICK = /(?:^|\.)kick\.com$/.test(location.hostname);
+
 	if (
-		// Don't run on certain sub-domains.
-		/^(?:localhost\.rig|blog|im|chatdepot|tmi|api|brand|dev|gql|passport)\./.test(location.hostname)
+		// Don't run on certain Twitch sub-domains. (Kick has its own
+		// infrastructure subdomains; we skip this check there.)
+		(!IS_KICK && /^(?:localhost\.rig|blog|im|chatdepot|tmi|api|brand|dev|gql|passport)\./.test(location.hostname))
+		||
+		// Don't run on Kick infrastructure subdomains either.
+		(IS_KICK && /^(?:api|files|dashboard)\./.test(location.hostname))
 		||
 		// Don't run on pages that have disabled FFZ.
 		/disable_frankerfacez/.test(location.search)
@@ -81,9 +87,10 @@
 		script = document.createElement('script');
 
 	let FLAVOR =
-			HOST.includes('player') ? 'player' :
-				HOST.includes('clips') ? 'clips' :
-					(location.pathname === '/p/ffz_bridge/' ? 'bridge' : 'avalon');
+			IS_KICK ? 'kick' :
+				HOST.includes('player') ? 'player' :
+					HOST.includes('clips') ? 'clips' :
+						(location.pathname === '/p/ffz_bridge/' ? 'bridge' : 'avalon');
 
 	if (FLAVOR === 'clips' && location.pathname === '/embed')
 		FLAVOR = 'player';

--- a/src/kick.js
+++ b/src/kick.js
@@ -1,0 +1,141 @@
+'use strict';
+
+// ============================================================================
+// FrankerFaceZ bootstrap for Kick.com (scaffold)
+// ============================================================================
+//
+// Mirrors src/player.js: a lean core that injects only the modules needed to
+// get FFZ running on a non-Twitch host. The site module itself is a stub
+// today (see src/sites/kick/index.js) — this entry point exists so the build
+// system produces a `kick.js` bundle that entry_ext.js can load when the
+// extension is on kick.com.
+
+import dayjs from 'dayjs';
+
+import Logger from 'utilities/logging';
+import Module from 'utilities/module';
+
+import {DEBUG} from 'utilities/constants';
+import {timeout} from 'utilities/object';
+
+import { installPort } from './utilities/extension_port';
+
+import SettingsManager from './settings/index';
+import ExperimentManager from './experiments';
+import TranslationManager from './i18n';
+import StagingSelector from './staging';
+import LoadTracker from './load_tracker';
+import Site from './sites/kick';
+
+class FrankerFaceZ extends Module {
+	constructor() {
+		super();
+		const start_time = performance.now();
+
+		FrankerFaceZ.instance = this;
+
+		this.host = 'kick';
+		this.flavor = 'kick';
+		this.name = 'ffz_kick';
+		this.__state = 0;
+		this.__modules.core = this;
+
+		this.log = new Logger(null, null, null);
+		this.log.label = 'FFZKick';
+		this.log.init = true;
+
+		this.core_log = this.log.get('core');
+		this.log.hi(this);
+
+		if (!! document.body.dataset.ffzExtension)
+			installPort(this);
+
+		this.inject('settings', SettingsManager);
+		this.inject('experiments', ExperimentManager);
+		this.inject('i18n', TranslationManager);
+		this.inject('staging', StagingSelector);
+		this.inject('load_tracker', LoadTracker);
+		this.inject('site', Site);
+
+		this.enable().then(() => {
+			const duration = performance.now() - start_time;
+			this.core_log.info(`Initialization complete in ${duration.toFixed(5)}ms.`);
+			this.log.init = false;
+		}).catch(err => {
+			this.core_log.error(`An error occurred during initialization.`, err);
+			this.log.init = false;
+		});
+	}
+
+	static get() {
+		return FrankerFaceZ.instance;
+	}
+
+	async generateLog() {
+		const promises = [];
+		for(const key in this.__modules) { // eslint-disable-line guard-for-in
+			const module = this.__modules[key];
+			if ( module instanceof Module && module.generateLog && module != this )
+				promises.push((async () => {
+					try {
+						return [
+							key,
+							await timeout(Promise.resolve(module.generateLog()), 5000)
+						];
+					} catch(err) {
+						return [
+							key,
+							`Error: ${err}`
+						]
+					}
+				})());
+		}
+
+		const out = await Promise.all(promises);
+
+		if ( this.log.captured_init && this.log.captured_init.length > 0 ) {
+			const logs = [];
+			for(const msg of this.log.captured_init) {
+				const time = dayjs(msg.time).locale('en').format('H:mm:ss');
+				logs.push(`[${time}] ${msg.level} | ${msg.category || 'core'}: ${msg.message}`);
+			}
+
+			out.unshift(['initialization', logs.join('\n')]);
+		}
+
+		return out.map(x => `${x[0]}
+-------------------------------------------------------------------------------
+${typeof x[1] === 'string' ? x[1] : JSON.stringify(x[1], null, 4)}`).join('\n\n');
+	}
+}
+
+
+FrankerFaceZ.Logger = Logger;
+
+const VER = FrankerFaceZ.version_info = Object.freeze({
+	major: __version_major__,
+	minor: __version_minor__,
+	revision: __version_patch__,
+	extra: __version_prerelease__?.length && __version_prerelease__[0],
+	commit: __git_commit__,
+	build: __version_build__,
+	hash: __webpack_hash__,
+	toString: () =>
+		`${VER.major}.${VER.minor}.${VER.revision}${VER.build ? `.${VER.build}` : ''}${VER.extra || ''}${DEBUG ? '-dev' : ''}`
+});
+
+FrankerFaceZ.utilities = {
+	constants: require('utilities/constants'),
+	dom: require('utilities/dom'),
+	events: require('utilities/events'),
+	logging: require('utilities/logging'),
+	module: require('utilities/module'),
+	object: require('utilities/object'),
+	time: require('utilities/time'),
+	i18n: require('utilities/translation-core'),
+	dayjs: require('dayjs')
+};
+
+
+window.FrankerFaceZ = FrankerFaceZ;
+window.ffz = new FrankerFaceZ();

--- a/src/sites/kick/index.js
+++ b/src/sites/kick/index.js
@@ -1,0 +1,65 @@
+'use strict';
+
+// ============================================================================
+// Site Support: Kick (scaffold)
+// ============================================================================
+//
+// This is an intentionally thin stub. It registers a BaseSite subclass so the
+// FFZ core can boot on kick.com and exposes hooks where Kick-specific modules
+// (chat, channel, emote rendering, React/webpack interception) will go.
+//
+// What still needs to be built, at minimum:
+//   - A Kick equivalent of utilities/compat/webmunch that knows Kick's
+//     webpack chunk-loading globals.
+//   - Fine predicates for Kick's React component tree (chat line, chat input,
+//     channel header, etc.).
+//   - A chat module that understands Kick's Pusher-based chat protocol
+//     rather than Twitch's IRC-style event stream.
+//   - A KickData module paralleling utilities/twitch-data for profile /
+//     channel / emote lookups against Kick's API.
+//
+// Reference implementation: src/sites/twitch-twilight/index.js
+
+import BaseSite from '../base';
+
+export default class Kick extends BaseSite {
+	constructor(...args) {
+		super(...args);
+
+		this.log.info('Kick site scaffold loaded. Integration is not yet functional.');
+	}
+
+	async onLoad() {
+		// Future: inject WebMunch/Fine/Router equivalents and populate
+		// Kick-specific modules via require.context, mirroring Twilight.
+	}
+
+	onEnable() {
+		this.settings = this.resolve('settings');
+
+		const update_size = () => this.settings.updateContext({
+			size: {
+				height: window.innerHeight,
+				width: window.innerWidth
+			}
+		});
+
+		window.addEventListener('resize', update_size);
+		update_size();
+
+		this.settings.updateContext({
+			route: {
+				name: 'kick-root',
+				parts: [location.pathname],
+				domain: location.hostname
+			},
+			route_data: [location.pathname]
+		});
+	}
+
+	getSession() { return null; }
+	getUser() { return null; }
+	getCore() { return null; }
+}
+
+Kick.CHAT_ROUTES = [];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,7 +52,8 @@ const ENTRY_POINTS = {
 	esbridge: './src/esbridge.js',
 	player: './src/player.js',
 	avalon: './src/main.ts',
-	clips: './src/clips.js'
+	clips: './src/clips.js',
+	kick: './src/kick.js'
 };
 
 if ( FOR_EXTENSION )


### PR DESCRIPTION
Adds a minimal BaseSite subclass, bootstrap entry, webpack entry, and entry_ext hostname detection for kick.com. The site module itself is a stub — Kick-specific WebMunch/Fine/chat modules still need to be built before FFZ is functional on Kick — but the build now produces a `kick.js` bundle and the content script will load it on kick.com when a future extension manifest update permits injection there.

Twitch behavior is unchanged: the twitch-twilight site, its webpack alias, and all existing entry points are untouched.

https://claude.ai/code/session_019JxF1BLBVVusW84KrfUCrG