### PR TITLE
Keepalive ping over ffz-cs-bridge port to prevent Firefox MV3 service-worker idle disconnects

### DIFF
--- a/src/entry_ext.js
+++ b/src/entry_ext.js
@@ -41,7 +41,9 @@
 					...msg
 				}, window.location.origin);
 			});
+			const ka = setInterval(() => { try { port.postMessage({ ffz_keepalive: true }); } catch (e) {} }, 25000);
 			port.onDisconnect.addListener(() => {
+				clearInterval(ka);
 				// Try to re-establish the connection.
 				console.log('FFZ-CS-Bridge: Disconnected, attempting to reconnect.');
 				setTimeout(initialize, 0);


### PR DESCRIPTION
 ka is closed over by both initialize()'s body and the onDisconnect listener, so each reconnect cycle gets its own interval and clearInterval(ka) clears the correct one. No worker-side change needed — Firefox's idle timer resets on port.postMessage receipt regardless of whether the worker actually handles the message. 
If the worker has a strict message router that warns on unknown types, a single if (msg?.ffz_keepalive) return; early-out would silence that, but it's cosmetic.

Should fix this console spam in FF: 
```
FFZ-CS-Bridge: Disconnected, attempting to reconnect. [script.min.js:1:797](moz-extension://8db77c2d-336f-4785-8e31-80a3a4c6d265/web/script.min.js)
FFZ-CS-Bridge: Disconnected, attempting to reconnect. [script.min.js:1:797](moz-extension://8db77c2d-336f-4785-8e31-80a3a4c6d265/web/script.min.js)
FFZ-CS-Bridge: Disconnected, attempting to reconnect. [script.min.js:1:797](moz-extension://8db77c2d-336f-4785-8e31-80a3a4c6d265/web/script.min.js)
FFZ-CS-Bridge: Disconnected, attempting to reconnect. [script.min.js:1:797](moz-extension://8db77c2d-336f-4785-8e31-80a3a4c6d265/web/script.min.js)
FFZ-CS-Bridge: Disconnected, attempting to reconnect. [script.min.js:1:797](moz-extension://8db77c2d-336f-4785-8e31-80a3a4c6d265/web/script.min.js)
FFZ-CS-Bridge: Disconnected, attempting to reconnect. [script.min.js:1:797](moz-extension://8db77c2d-336f-4785-8e31-80a3a4c6d265/web/script.min.js)
FFZ-CS-Bridge: Disconnected, attempting to reconnect. [script.min.js:1:797](moz-extension://8db77c2d-336f-4785-8e31-80a3a4c6d265/web/script.min.js)
FFZ-CS-Bridge: Disconnected, attempting to reconnect. [script.min.js:1:797](moz-extension://8db77c2d-336f-4785-8e31-80a3a4c6d265/web/script.min.js)
FFZ-CS-Bridge: Disconnected, attempting to reconnect. [script.min.js:1:797](moz-extension://8db77c2d-336f-4785-8e31-80a3a4c6d265/web/script.min.js)
FFZ-CS-Bridge: Disconnected, attempting to reconnect. [script.min.js:1:797](moz-extension://8db77c2d-336f-4785-8e31-80a3a4c6d265/web/script.min.js)
FFZ-CS-Bridge: Disconnected, attempting to reconnect. [script.min.js:1:797](moz-extension://8db77c2d-336f-4785-8e31-80a3a4c6d265/web/script.min.js)
FFZ-CS-Bridge: Disconnected, attempting to reconnect. [script.min.js:1:797](moz-extension://8db77c2d-336f-4785-8e31-80a3a4c6d265/web/script.min.js)

```
​