### PR TITLE
* Fixed: Emote menu freezing the page when logged out/incognito

### DIFF
--- a/src/sites/twitch-twilight/modules/chat/emote_menu.jsx
+++ b/src/sites/twitch-twilight/modules/chat/emote_menu.jsx
@@ -3007,7 +3007,7 @@ export default class EmoteMenu extends Module {
 	async getFFZSubData() {
 		const me = this.resolve('site').getUser();
 		if ( ! me )
-			return null;
+			return {error: true};
 
 		const token = await this.resolve('socket').getBareAPIToken();
 		if ( ! token )


### PR DESCRIPTION
Instead of freezing the entire page, emote menu now opens up as expected.