### PR TITLE
Fix "Display mentions in chat with a bold font" option

### DIFF
--- a/src/sites/twitch-twilight/modules/css_tweaks/styles/chat-mention-no-bold.scss
+++ b/src/sites/twitch-twilight/modules/css_tweaks/styles/chat-mention-no-bold.scss
@@ -1,3 +1,3 @@
 strong.chat-line__message-mention {
-	font-weight: 100 !important;
+	font-weight: var(--font-weight-normal) !important;
 }


### PR DESCRIPTION
Apparently twitch now uses [variable](https://en.wikipedia.org/wiki/Variable_font) version of [Inter](https://fonts.google.com/specimen/Inter) font, and `font-weight: 100` is too thin.

| Before  | After  |
| - | - |
| <img width="631" height="634" alt="image" src="https://github.com/user-attachments/assets/7cb37d24-ffab-44d3-933b-b1624d843d7e" /> | <img width="643" height="642" alt="image" src="https://github.com/user-attachments/assets/d4e4bda9-b02d-4a43-a6e7-b442eaa09d62" /> |

