### PR TITLE
Display volume percentage tooltip when adjusting volume with mouse wheel

### DIFF
--- a/src/sites/shared/player.jsx
+++ b/src/sites/shared/player.jsx
@@ -823,6 +823,11 @@ export default class PlayerBase extends Module {
 			if ( this._ffz_state_raf )
 				cancelAnimationFrame(this._ffz_state_raf);
 
+			if ( this._ffz_vol_tooltip_timer ) {
+				clearTimeout(this._ffz_vol_tooltip_timer);
+				this._ffz_vol_tooltip_timer = null;
+			}
+
 			const events = this.props.playerEvents;
 			if ( events && this._ffzUpdateState ) {
 				off(events, 'Playing', this._ffzUpdateState);
@@ -921,10 +926,14 @@ export default class PlayerBase extends Module {
 			if ( ! this._ffz_menu_handler )
 				this._ffz_menu_handler = this.ffzMenuHandler.bind(this);
 
+			if ( ! this._ffz_vol_mouseover_handler )
+				this._ffz_vol_mouseover_handler = this.ffzVolumeMouseOver.bind(this);
+
 			on(cont, 'wheel', this._ffz_scroll_handler);
 			on(cont, 'dblclick', this._ffz_dblclick_handler);
 			on(cont, 'mousedown', this._ffz_click_handler);
 			on(cont, 'contextmenu', this._ffz_menu_handler);
+			on(cont, 'mouseover', this._ffz_vol_mouseover_handler);
 		}
 
 		cls.prototype.ffzRemoveListeners = function() {
@@ -950,6 +959,11 @@ export default class PlayerBase extends Module {
 			if ( this._ffz_dblclick_handler ) {
 				off(cont, 'dblclick', this._ffz_dblclick_handler);
 				this._ffz_dblclick_handler = null;
+			}
+
+			if ( this._ffz_vol_mouseover_handler ) {
+				off(cont, 'mouseover', this._ffz_vol_mouseover_handler);
+				this._ffz_vol_mouseover_handler = null;
 			}
 
 			this._ffz_listeners = false;
@@ -1086,10 +1100,35 @@ export default class PlayerBase extends Module {
 					player.setMuted(false);
 					localStorage.setItem('video-muted', JSON.stringify({default: false}));
 				}
+
+				const cont = this.props.containerRef;
+				const input = cont?.querySelector('input[data-a-target="player-volume-slider"]');
+				if ( input ) {
+					input.dispatchEvent(new FocusEvent('focusout', {bubbles: true}));
+					input.dispatchEvent(new FocusEvent('focusin', {bubbles: true}));
+					if ( this._ffz_vol_tooltip_timer )
+						clearTimeout(this._ffz_vol_tooltip_timer);
+					this._ffz_vol_tooltip_timer = setTimeout(() => {
+						input.dispatchEvent(new FocusEvent('focusout', {bubbles: true}));
+						this._ffz_vol_tooltip_timer = null;
+					}, 1500);
+				}
 			}
 
 			event.preventDefault();
 			return false;
+		}
+
+		cls.prototype.ffzVolumeMouseOver = function (event) {
+			if (!event.target.matches('input[data-a-target="player-volume-slider"]'))
+				return;
+
+			if ( this._ffz_vol_tooltip_timer ) {
+				clearTimeout(this._ffz_vol_tooltip_timer);
+				this._ffz_vol_tooltip_timer = null;
+			}
+
+			event.target.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
 		}
 
 		cls.prototype.ffzMaybeRemoveNativeListeners = function() {


### PR DESCRIPTION
Before | After
--- | --- 
<img width="298" height="146" src="https://github.com/user-attachments/assets/d5e1b8a1-2702-4a89-8df4-4376e036f835" /> | <img width="311" height="161" src="https://github.com/user-attachments/assets/e75f9314-8584-49b3-8210-a93ce71b6aab" />

<sup>This also makes it so you'll see the tooltip if you hover over the volume knob/slider</sup>

**Note:** On each session, the tooltip will snap from the mute button to it's correct position. Small trade-off I guess?
<img width="289" height="168" src="https://github.com/user-attachments/assets/251072c8-c7d2-4db5-92f5-0f6620c9327c" />
