### PR TITLE
Fix lead moderator commands missing from chat command suggestions

### DIFF
--- a/src/sites/twitch-twilight/modules/chat/input.jsx
+++ b/src/sites/twitch-twilight/modules/chat/input.jsx
@@ -810,7 +810,8 @@ export default class Input extends Module {
 
 		inst.getCommands = function(input) { try {
 			const commands = inst.props.getCommands(inst.props.permissionLevel, {
-				isEditor: inst.props.isCurrentUserEditor
+				isEditor: inst.props.isCurrentUserEditor,
+				hasPermissions: inst.props.chatCommandPermissions
 			});
 
 			// Get the parent-input so we can do stuff.


### PR DESCRIPTION
Twitch gates `/mod`, `/unmod`, `/vip`, and `/unvip` behind a `permissionAllowsUsage` field that is checked against a `hasPermissions` Set passed into `getCommands`.
FFZ's override of `getCommands` in `CommandSuggestions` was not forwarding `chatCommandPermissions` from props at all, so the permission check always failed and those commands were never included in the suggestions list.

This only affected lead moderators. (not broadcasters)

For debugging,
```js
const inst = ffz.site.children.chat.input.CommandSuggestions.first;
// Before
inst.props.getCommands(inst.props.permissionLevel, { isEditor: inst.props.isCurrentUserEditor });

// After
inst.props.getCommands(inst.props.permissionLevel, { isEditor: inst.props.isCurrentUserEditor, hasPermissions: inst.props.chatCommandPermissions });


Object.keys(inst.props)
inst.props.chatCommandPermissions
inst.oldCommands.toString()
inst.props.getCommands.toString()
```