### PR TITLE
player: preserve playback intent when the compressor recreates the video element

### DIFF
--- a/src/sites/shared/player.jsx
+++ b/src/sites/shared/player.jsx
@@ -1540,6 +1540,13 @@ export default class PlayerBase extends Module {
 		if ( muted )
 			new_vid.muted = true;
 		new_vid.playsInline = true;
+		// Carry playback intent onto the replacement element so it resumes after the
+		// following player.load() instead of landing paused — otherwise, when something
+		// recreates the element mid-session (e.g. a player reload), the fresh element can
+		// stay paused and require a manual play click. Twitch drives playback with
+		// programmatic play() and does not set the autoplay attribute, so also derive
+		// intent from whether the old element was actually playing.
+		new_vid.autoplay = video.autoplay || ( video && ! video.paused && ! video.ended );
 
 		this.installPlaybackRate(new_vid);
 		video.replaceWith(new_vid);


### PR DESCRIPTION
### Summary

When the Audio Compressor is enabled, `hookPlayerLoad` replaces the `<video>` element on every `player.load()` — necessary because once an element is routed through `createMediaElementSource` it's permanently tied to that Web Audio graph, so a fresh element is required for the reload to play. `replaceVideoElement` carries over `volume`, `muted`, and the `_ffz_*` state, but **not playback intent**, so the replacement element can land **paused** and require a manual play click.

This is most visible when *something external* recreates the player mid-session — e.g. an ad-blocking userscript/extension that reloads the player at the end of an ad break. With the compressor on, each such reload swaps in a fresh element that may not auto-resume, so the stream sits paused until the user clicks play. (Reported downstream against a Twitch ad-block scriptlet, but the gap is in the compressor's element-recreation itself.)

### Change

One line in `replaceVideoElement`: carry autoplay intent onto the new element.

```js
new_vid.autoplay = video.autoplay || ( video && ! video.paused && ! video.ended );
```

Twitch drives playback with programmatic `play()` and doesn't set the `autoplay` attribute, so copying `video.autoplay` alone is usually a no-op — the `!paused && !ended` term derives the real intent from whether the outgoing element was actually playing.

### Scope / caveats

- Only affects the element the compressor recreates; no change when the compressor is off (`replaceVideoElement` only runs via the compressor's `hookPlayerLoad`).
- The muted case resumes cleanly. Unmuted playback is *encouraged* but still subject to the browser's autoplay policy on a freshly-created element, so this is a best-effort resume, not a guarantee.
- Doesn't change *why* the element is recreated (the Web Audio taint makes that necessary) — only that the replacement inherits the old element's play state.

Happy to adjust naming/placement to match your preferences.