### PR TITLE
Added new setting to toggle case-sensitive sort in the tab emote menu.

### DIFF
--- a/src/sites/twitch-twilight/modules/chat/input.jsx
+++ b/src/sites/twitch-twilight/modules/chat/input.jsx
@@ -25,6 +25,8 @@ const NON_PREFIX_MATCH = 2;
 const CASE_INSENSITIVE_PREFIX_MATCH = 3;
 const EXACT_PREFIX_MATCH = 4;
 
+const DEFAULT_CASE_SENSITIVE_VALUE = true;
+
 function getNodeText(node) {
 	if ( ! node )
 		return '';
@@ -147,8 +149,28 @@ export default class Input extends Module {
 			}
 		});
 
+		const outerThis = this;
 		this.settings.add('chat.tab-complete.prioritize-prefix-matches', {
 			default: false,
+			// using process() to detect changes because changed() never triggers
+			process(ctx, val) {
+				// Only show the case-sensitive setting because it depends on the prefix matches setting.
+				if (val) {
+					outerThis.settings.add('chat.tab-complete.prioritize-prefix-matches.case-sensitive', {
+						default: DEFAULT_CASE_SENSITIVE_VALUE,
+						requires: ['chat.tab-complete.prioritize-prefix-matches'],
+						ui: {
+							path: 'Chat > Input >> Tab Completion',
+							title: 'Matching start input is case-sensitive.',
+							component: 'setting-check-box'
+						},
+					});
+				} else {
+					outerThis.settings.remove('chat.tab-complete.prioritize-prefix-matches.case-sensitive');
+				}
+
+				return val;
+			},
 			ui: {
 				path: 'Chat > Input >> Tab Completion',
 				title: 'Prioritize emotes that start with user input.',
@@ -1077,6 +1099,9 @@ export default class Input extends Module {
 		const preferFavorites = this.chat.context.get('chat.tab-complete.prioritize-favorites');
 		const canBeTriggeredByTab = this.chat.context.get('chat.tab-complete.emotes-without-colon');
 		const prioritizePrefixMatches = this.chat.context.get('chat.tab-complete.prioritize-prefix-matches');
+		// Check if the setting is enabled, if true get value otherwise use default
+		const caseDefinition = this.settings.definitions.get('chat.tab-complete.prioritize-prefix-matches.case-sensitive');
+		const caseSensitive = caseDefinition ? this.chat.context.get('chat.tab-complete.prioritize-prefix-matches.case-sensitive') : DEFAULT_CASE_SENSITIVE_VALUE;
 
 		return emotes.sort((a, b) => {
 			const aStr = a.matched || a.replacement;
@@ -1095,11 +1120,13 @@ export default class Input extends Module {
 					else return 0 - bIsEmoji + aIsEmoji;
 				}
 
-				// Prefer case-sensitive prefix matches
-				const aStartsWithInput = (a.match_type === EXACT_PREFIX_MATCH);
-				const bStartsWithInput = (b.match_type === EXACT_PREFIX_MATCH);
+				// If the sort is case-insensitive then treat both cases as equal, otherwise prefer the case-sensitive matches
+				const aStartsWithInput = (a.match_type === EXACT_PREFIX_MATCH 
+					|| (!caseSensitive && a.match_type === CASE_INSENSITIVE_PREFIX_MATCH));
+				const bStartsWithInput = (b.match_type === EXACT_PREFIX_MATCH 
+					|| (!caseSensitive && b.match_type === CASE_INSENSITIVE_PREFIX_MATCH));
 				if (aStartsWithInput && bStartsWithInput)
-					return locale.compare(aStr, bStr);
+					return caseSensitive ? locale.compare(aStr, bStr) : localeCaseInsensitive.compare(aStr, bStr);
 				else if (aStartsWithInput) return -1;
 				else if (bStartsWithInput) return 1;
 


### PR DESCRIPTION
When using the setting `Prioritize emotes that start with user input`, the sort is strictly case-sensitive. This new setting allows toggling the case-sensitiveness when sorting.

A common use case is when there is a mix of lower and uppercase emotes starting the same way, the uppercase emotes usually get pushed below forcing the user to use caps to look for them.

Here's an example while typing "pol" and see how the emotes that start with P don't get below the p emotes anymore, but instead are sorted alphabetically.

Case-sensitive (current and default)
<img width="466" height="354" alt="case-sensitive" src="https://github.com/user-attachments/assets/a38cda29-0da5-4161-96ea-4d78eeae6bc0" />
Case-insensitive
<img width="464" height="349" alt="case-insensitive" src="https://github.com/user-attachments/assets/eae6627a-3f14-4de1-be1e-9f17e65f0016" />
