### PR TITLE
* Fixed: .ffz-balloon tail not rendering due to mismatched class name

### DIFF
--- a/styles/native/balloon.scss
+++ b/styles/native/balloon.scss
@@ -7,7 +7,7 @@
 		height: 16px;
 		width: 16px;
 
-		& .ffz-balloon-symbol {
+		& .ffz-balloon__tail-symbol {
 			height: 8px;
 			transform: rotate(45deg) translate(-50%,-50%);
 			transform-origin: 0 0;


### PR DESCRIPTION
Fixes the small triangular "tail" on `.ffz-balloon` elements, which currently never renders.

Before | After
--- | --- 
<img width="111" height="66" src="https://github.com/user-attachments/assets/47c02369-0575-4977-b1a1-4b6cb970fc36" /> | <img width="114" height="77" src="https://github.com/user-attachments/assets/e0943c02-d3cc-4705-931c-96eb6d94b801" />

Before | After
--- | --- 
<img width="177" height="51" src="https://github.com/user-attachments/assets/c228dec5-f699-42af-b581-0c8c2af481ed" /> | <img width="185" height="35" src="https://github.com/user-attachments/assets/6e345a10-d05b-49d3-aba7-b0220d174f31" />

...and possibly in other places too.