### PR TITLE
Added a dev flag that allows disabling cache busting for addons.

### DIFF
--- a/src/addons.ts
+++ b/src/addons.ts
@@ -572,10 +572,12 @@ export default class AddonManager extends Module<'addons'> {
 			return;
 		}
 
+		// If cache busting is enabled, add timestamp suffix.
+		const script_filename =  `script.js${addon.disable_cache_busting ? '' : `?_=${getBuster(30)}`}`;
 		document.head.appendChild(createElement('script', {
 			id: `ffz-loaded-addon-${addon.id}`,
 			type: 'text/javascript',
-			src: addon.src || `${addon.dev ? 'https://localhost:8001/script' : SERVER_OR_EXT}/addons/${addon.id}/script.js?_=${getBuster(30)}`,
+			src: addon.src || `${addon.dev ? 'https://localhost:8001/script' : SERVER_OR_EXT}/addons/${addon.id}/${script_filename}`,
 			crossorigin: 'anonymous'
 		}));
 

--- a/src/utilities/types.ts
+++ b/src/utilities/types.ts
@@ -91,6 +91,9 @@ export type AddonInfo = {
 	/** Optional. List of load tracker events that this add-on should hold while it's being loaded. */
 	load_events?: string[];
 
+	/** Flag to configure whether script filenames have a timestamp suffix that prevents caching*/
+	disable_cache_busting: boolean;
+
 };
 
 export type BasicAddonInfo = Pick<AddonInfo, 'id'> & Partial<AddonInfo>;


### PR DESCRIPTION
The addons have a script filename like this `script.js?_=1782877783589` where the parameter after the extension is a timestamp that changes on reload, this is used for cache busting. Unfortunately, cache busting makes debugging addons more difficult because breakpoints are not preserved when reloading the page, which makes it impossible to use the debugger in many parts of the code, e.g., a class's constructor.

Added a new flag `disable_cache_busting` that developers can use to temporarily disable cache busting and allow them to use the debugger in those scenarios. This flag can be set in the addon's manifest.

