### PR TITLE
* Fixed: Missing horizontal padding on notice-style chat lines

### DIFF
--- a/src/sites/twitch-twilight/modules/chat/line.js
+++ b/src/sites/twitch-twilight/modules/chat/line.js
@@ -1486,7 +1486,7 @@ other {# messages were deleted by a moderator.}
 						);
 					}
 
-					klass = `${klass} ffz-notice-line user-notice-line tw-pd-y-05`;
+					klass = `${klass} ffz-notice-line user-notice-line tw-pd-x-1 tw-pd-y-05`;
 
 					if ( ! is_raw )
 						notice = e('div', {


### PR DESCRIPTION
Without `tw-pd-x-1` applied, <sup>(having **Reduce padding around lines** enabled would "fix" this previously)</sup>

Before (w/o timestamp, reduce chat lines) | Before (w/ timestamp, w/o reduce chat lines) | Before (w/ timestamp, reduce chat lines)
--- | --- | --- 
<img width="444" height="77" src="https://github.com/user-attachments/assets/d5c4f901-3c78-43ec-9003-f76661f280d1" /> | <img width="443" height="78" src="https://github.com/user-attachments/assets/03c05b8d-65d2-4176-904e-f935f758c5cc" /> | <img width="444" height="77" src="https://github.com/user-attachments/assets/e1a2b3d5-9783-460b-a0d6-6a767d5df916" />


With `tw-pd-x-1` applied,

After (w/o timestamp, reduce chat lines) | After (w/ timestamp, w/o reduce chat lines) | After (w/ timestamp, reduce chat lines)
--- | --- | --- 
<img width="444" height="77" src="https://github.com/user-attachments/assets/4e093e2f-c3f4-45e3-a938-9fb182fb753a" /> | <img width="444" height="76" src="https://github.com/user-attachments/assets/21be1e2a-0323-4692-87e9-7bf0aee054c0" /> | <img width="444" height="77" src="https://github.com/user-attachments/assets/6b6cbdb2-280a-42a7-91fa-2c64ae77eaac" />


